### PR TITLE
feat: adds google framework prefix for isFramework

### DIFF
--- a/cpp/profiler/JavaBaseTracer.h
+++ b/cpp/profiler/JavaBaseTracer.h
@@ -45,8 +45,9 @@ class JavaBaseTracer : public BaseTracer {
                                                  {"Landroid", 8},
                                                  {"Ldalvik", 7},
                                                  {"Lcom/android", 12},
-                                                 {"Lorg/apache", 11}};
-    constexpr int framework_prefixes_len = 5;
+                                                 {"Lorg/apache", 11},
+                                                 {"Lcom/google", 11}};
+    constexpr int framework_prefixes_len = 6;
     for (int i = 0; i < framework_prefixes_len; i++) {
       auto& p = prefixes[i];
       if (strncmp(name, p.name, p.length) == 0) {


### PR DESCRIPTION
Added google framework prefixes for the methods in <a href="https://github.com/facebookincubator/profilo/blob/master/cpp/profiler/JavaBaseTracer.h">JavaBaseTracer.h</a> isFramework function to whitelist all the methods that can be injected through `com/google` code.

Referencing the issue #48 : [https://github.com/facebookincubator/profilo/issues/48](url)