### PR TITLE
Add framework frames information to Dalvik trace logs

### DIFF
--- a/cpp/profiler/DalvikTracer.cpp
+++ b/cpp/profiler/DalvikTracer.cpp
@@ -68,9 +68,11 @@ DalvikTracer::DalvikTracer()
     : dvmThreadSelf_(
           reinterpret_cast<decltype(dvmThreadSelf_)>(getDvmThreadSelf())) {}
 
-StackCollectionRetcode DalvikTracer::collectStack(
+StackCollectionRetcode DalvikTracer::collectJavaStack(
     ucontext_t*,
     int64_t* frames,
+    char const** method_names,
+    char const** class_descriptors,
     uint8_t& depth,
     uint8_t max_depth) {
   Thread* thread = dvmThreadSelf_();
@@ -89,18 +91,33 @@ StackCollectionRetcode DalvikTracer::collectStack(
     StackSaveArea* saveArea = SAVEAREA_FROM_FP(fp);
     const Method* method = saveArea->method;
 
-    if (method != nullptr) {
-      frames[depth] = dalvikGetMethodIdForSymbolication(method);
-      depth++;
+    fp = saveArea->prevFrame;
+
+    if (method == nullptr) {
+      continue;
     }
 
-    fp = saveArea->prevFrame;
+    if (method_names != nullptr && class_descriptors != nullptr) {
+      method_names[depth] = method->name;
+      class_descriptors[depth] = method->clazz->descriptor;
+    }
+
+    frames[depth] = dalvikGetMethodIdForSymbolication(method);
+    depth++;
   }
 
   if (depth == 0) {
     return StackCollectionRetcode::EMPTY_STACK;
   }
   return StackCollectionRetcode::SUCCESS;
+}
+
+StackCollectionRetcode DalvikTracer::collectStack(
+    ucontext_t* ucontext,
+    int64_t* frames,
+    uint8_t& depth,
+    uint8_t max_depth) {
+      return collectJavaStack(ucontext, frames, nullptr, nullptr, depth, max_depth);
 }
 
 void DalvikTracer::flushStack(

--- a/cpp/profiler/DalvikTracer.h
+++ b/cpp/profiler/DalvikTracer.h
@@ -20,8 +20,8 @@
 
 #include <dalvik-subset/internals.h>
 
-#include <profiler/BaseTracer.h>
 #include <profilo/Logger.h>
+#include <profiler/JavaBaseTracer.h>
 
 namespace facebook {
 namespace profilo {
@@ -29,7 +29,7 @@ namespace profiler {
 
 using dvmThreadSelf_t = Thread* (*)();
 
-class DalvikTracer : public BaseTracer {
+class DalvikTracer : public JavaBaseTracer {
  public:
   DalvikTracer();
 
@@ -39,6 +39,14 @@ class DalvikTracer : public BaseTracer {
   StackCollectionRetcode collectStack(
       ucontext_t* ucontext,
       int64_t* frames,
+      uint8_t& depth,
+      uint8_t max_depth) override;
+
+  StackCollectionRetcode collectJavaStack(
+      ucontext_t* ucontext,
+      int64_t* frames,
+      char const** method_names,
+      char const** class_descriptors,
       uint8_t& depth,
       uint8_t max_depth) override;
 

--- a/cpp/profiler/JavaBaseTracer.h
+++ b/cpp/profiler/JavaBaseTracer.h
@@ -59,8 +59,11 @@ class JavaBaseTracer : public BaseTracer {
 
   // Keep these in sync with all ART_UNWINDC_* from BaseTracer
   static bool isJavaTracer(int32_t type) {
-    return type == tracers::ART_UNWINDC_5_0 ||
-        type == tracers::ART_UNWINDC_5_1 || type == tracers::ART_UNWINDC_6_0 ||
+    return
+        type == tracers::DALVIK ||
+        type == tracers::ART_UNWINDC_5_0 ||
+        type == tracers::ART_UNWINDC_5_1 ||
+        type == tracers::ART_UNWINDC_6_0 ||
         type == tracers::ART_UNWINDC_7_0_0 ||
         type == tracers::ART_UNWINDC_7_1_0 ||
         type == tracers::ART_UNWINDC_7_1_1 ||


### PR DESCRIPTION
Currently stack trace provider doesn't identify framework frames from Dalvik tracer, this PR adds logic to enable logging f/w frames for the same. Closes #52 