### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,6 +14,10 @@ module.exports = {
   organizationName: "facebookincubator", // Usually your GitHub org/user name.
   projectName: "profilo", // Usually your repo name.
   themeConfig: {
+    algolia: {
+      apiKey: '2d1e716ad64b24b64f695105790461a5',
+      indexName: 'profilo',
+    },
     navbar: {
       title: "Profilo",
       logo: {


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.