### PR TITLE
Back out "Moving robolectric tests in `com.facebook` to use static di 4"

### DIFF
--- a/java/main/com/facebook/profilo/core/BUCK
+++ b/java/main/com/facebook/profilo/core/BUCK
@@ -86,7 +86,7 @@ fb_core_android_library(
     required_for_source_only_abi = True,
     visibility = [
         profilo_path("..."),
-        "//fbandroid/javatests/com/facebook/cloudseeder:",
+        "//fbandroid/javatests/com/facebook/cloudseeder:cloudseeder",
         "//fbandroid/javatests/com/facebook/debug/fps:fps",
         "//fbandroid/javatests/com/facebook/stall:",
         "//fbandroid/perftests/benchmarks/java/com/facebook/benchmarks/profilo/...",
@@ -163,7 +163,7 @@ fb_core_android_library(
         "//fbandroid/java/com/facebook/tools/dextr/...",
         "//fbandroid/java/com/facebook/video/profiler/systrace:systrace",
         "//fbandroid/java/com/instagram/android/...",
-        "//fbandroid/javatests/com/facebook/cloudseeder:",
+        "//fbandroid/javatests/com/facebook/cloudseeder:cloudseeder",
         "//fbandroid/javatests/com/facebook/tools/dextr/...",
         profilo_path("..."),
     ],


### PR DESCRIPTION
Summary: Original commit changeset: 1a86bf8db002

Differential Revision: D20699388

