### PR TITLE
Install python3 for oss build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends ant git default-jdk python wget unzip
+RUN apt-get install -y --no-install-recommends ant git default-jdk python wget unzip python3
 
 RUN mkdir -p /scripts/
 

--- a/build/setup_buck.sh
+++ b/build/setup_buck.sh
@@ -3,7 +3,7 @@
 set -e
 
 pushd /
-git clone https://github.com/facebook/buck.git
+git clone --depth 1 https://github.com/facebook/buck.git
 cd buck
 ANT_OPTS=-Xmx1024m ant default
 popd


### PR DESCRIPTION
This PR installs python3 as buck now needs it, and also speeds up buck checkouts a tiny bit.