### PR TITLE
Add no-op circle config for gh-pages that Docusaurus will leave alone

### DIFF
--- a/website/static/.circleci/config.yml
+++ b/website/static/.circleci/config.yml
@@ -1,0 +1,19 @@
+# No-op config to make Circle stop complaining about 
+# builds failing on the gh-pages branch due to lack of config.yml
+#
+version: 2.1
+
+jobs:
+  noop:
+    docker:
+      - image: cimg/python:3.7
+    steps:
+      - run: echo "noop"
+
+workflows:
+  noop:
+    jobs:
+      - noop:
+          filters:
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
CircleCI needs a no-op config on gh-pages or else it fails on every commit with "missing config.yml". 

I added such a config for facebookincubator/profilo in [this commit](https://github.com/facebookincubator/profilo/commit/4bee4f643eda28e0b0dc76f42734cc4dca83ce3e). As you can see, the builds went green.

However, the [subsequent docusaurus push](https://github.com/facebookincubator/profilo/commit/39d2ce5cfdbb7a902d742281aeaea2ae55b1e8dc) ([just `yarn run deploy` from master](https://github.com/facebookincubator/profilo/blob/master/.circleci/config.yml#L77)) deleted the config.

Following the discussion on https://github.com/facebook/docusaurus/issues/2990, I'm adding the circleci config in `static` so it gets pushed to the root of the gh-pages branch by Docusaurus itself.

I have verified that a website build does indeed contain the new config file:

```
[~/dev/profilo/website] 
> cat build/.circleci/config.yml 
# No-op config to make Circle stop complaining about 
# builds failing on the gh-pages branch due to lack of config.yml
#
version: 2.1

jobs:
  noop:
    docker:
      - image: cimg/python:3.7
    steps:
      - run: echo "noop"

workflows:
  noop:
    jobs:
      - noop:
          filters:
            branches:
              ignore: /.*/
```