### PR TITLE
[profilo][oss] Specify known-good version of Buck

### DIFF
--- a/build/setup_buck.sh
+++ b/build/setup_buck.sh
@@ -3,7 +3,9 @@
 set -e
 
 pushd /
-git clone --depth 1 https://github.com/facebook/buck.git
+git clone --depth 500 https://github.com/facebook/buck.git
 cd buck
+# check out known good buck version from Jun 29 07:46:12 2020:
+git checkout 3283f1ca2bb3ce3aa809da5f516c42009ec3a1d9
 ANT_OPTS=-Xmx1024m ant default
 popd


### PR DESCRIPTION
This diff pins Buck to a known-good version:
- version 3283f1ca2bb3ce3aa809da5f516c42009ec3a1d9 from June 29, 2020.

This will hopefully address Travis build errors.