### PR TITLE
{feat} add stack unwind support on Android10.0 now for arm/arm64

### DIFF
--- a/cpp/profiler/ArtCompatibility.cpp
+++ b/cpp/profiler/ArtCompatibility.cpp
@@ -27,6 +27,7 @@
 #include "profiler/ArtUnwindcTracer_800.h"
 #include "profiler/ArtUnwindcTracer_810.h"
 #include "profiler/ArtUnwindcTracer_900.h"
+#include "profiler/ArtUnwindcTracer_1000.h"
 #include "profiler/BaseTracer.h"
 
 #include <fb/log.h>
@@ -75,6 +76,9 @@ jboolean check(JNIEnv* env, jclass, jint tracers) {
   } else if (tracers & ART_UNWINDC_9_0_0) {
     auto tracer = std::make_unique<profiler::ArtUnwindcTracer900>();
     return runJavaCompatibilityCheck(versions::ANDROID_9_0, tracer.get());
+  } else if (tracers & ART_UNWINDC_10_0_0) {
+    auto tracer = std::make_unique<profiler::ArtUnwindcTracer1000>();
+    return runJavaCompatibilityCheck(versions::ANDROID_10_0, tracer.get());
   } else {
     return false;
   }

--- a/cpp/profiler/ArtCompatibilityRunner.h
+++ b/cpp/profiler/ArtCompatibilityRunner.h
@@ -29,6 +29,7 @@ enum AndroidVersion : uint8_t {
   ANDROID_8_0,
   ANDROID_8_1,
   ANDROID_9_0,
+  ANDROID_10_0,
 };
 } // namespace versions
 

--- a/cpp/profiler/ArtUnwindcTracer.cpp
+++ b/cpp/profiler/ArtUnwindcTracer.cpp
@@ -47,6 +47,8 @@ static constexpr ArtUnwindcVersion kVersion = kArtUnwindc800;
 static constexpr ArtUnwindcVersion kVersion = kArtUnwindc810;
 #elif ANDROID_VERSION_NUM == 900
 static constexpr ArtUnwindcVersion kVersion = kArtUnwindc900;
+#elif ANDROID_VERSION_NUM == 1000
+static constexpr ArtUnwindcVersion kVersion = kArtUnwindc1000;
 #endif
 
 /**

--- a/cpp/profiler/ArtUnwindcTracer.h
+++ b/cpp/profiler/ArtUnwindcTracer.h
@@ -34,7 +34,8 @@ enum ArtUnwindcVersion {
   kArtUnwindc712,
   kArtUnwindc800,
   kArtUnwindc810,
-  kArtUnwindc900
+  kArtUnwindc900,
+  kArtUnwindc1000
 };
 
 template <ArtUnwindcVersion kVersion>
@@ -105,6 +106,10 @@ using ArtUnwindcTracer810 = ArtUnwindcTracer<kArtUnwindc810>;
 #ifdef ANDROID_VERSION_900
 template class ArtUnwindcTracer<kArtUnwindc900>;
 using ArtUnwindcTracer900 = ArtUnwindcTracer<kArtUnwindc900>;
+#endif
+#ifdef ANDROID_VERSION_1000
+template class ArtUnwindcTracer<kArtUnwindc1000>;
+using ArtUnwindcTracer1000 = ArtUnwindcTracer<kArtUnwindc1000>;
 #endif
 
 } // namespace profiler

--- a/cpp/profiler/BUCK
+++ b/cpp/profiler/BUCK
@@ -25,6 +25,11 @@ unwindc_tracer_library(
     version = "9.0.0",
 )
 
+unwindc_tracer_library(
+    allow_64bit = True,
+    version = "10.0.0",
+)
+
 fb_xplat_cxx_library(
     name = "constants",
     header_namespace = "profiler",
@@ -76,6 +81,7 @@ fb_xplat_cxx_library(
         ":unwindc-tracer-8.0.0",
         ":unwindc-tracer-8.1.0",
         ":unwindc-tracer-9.0.0",
+        ":unwindc-tracer-10.0.0",
         profilo_path("deps/fb:fb"),
         profilo_path("deps/fbjni:fbjni"),
         profilo_path("deps/forkjail:forkjail"),
@@ -314,6 +320,7 @@ fb_xplat_cxx_library(
         ":unwindc-tracer-8.0.0",
         ":unwindc-tracer-8.1.0",
         ":unwindc-tracer-9.0.0",
+        ":unwindc-tracer-10.0.0",
         profilo_path("cpp:constants"),
         profilo_path("cpp:profilo"),
         profilo_path("cpp:providers"),

--- a/cpp/profiler/BaseTracer.h
+++ b/cpp/profiler/BaseTracer.h
@@ -44,6 +44,7 @@ enum Tracer : uint32_t {
   ART_UNWINDC_8_0_0 = 1 << 12,
   ART_UNWINDC_8_1_0 = 1 << 13,
   ART_UNWINDC_9_0_0 = 1 << 14,
+  ART_UNWINDC_10_0_0 = 1 << 15,
 };
 }
 

--- a/cpp/profiler/JavaBaseTracer.h
+++ b/cpp/profiler/JavaBaseTracer.h
@@ -67,7 +67,8 @@ class JavaBaseTracer : public BaseTracer {
         type == tracers::ART_UNWINDC_7_1_2 ||
         type == tracers::ART_UNWINDC_8_0_0 ||
         type == tracers::ART_UNWINDC_8_1_0 ||
-        type == tracers::ART_UNWINDC_9_0_0;
+        type == tracers::ART_UNWINDC_9_0_0 ||
+        type == tracers::ART_UNWINDC_10_0_0;
   }
 };
 

--- a/cpp/profiler/SamplingProfiler.cpp
+++ b/cpp/profiler/SamplingProfiler.cpp
@@ -44,6 +44,7 @@
 #include <profiler/ArtUnwindcTracer_800.h>
 #include <profiler/ArtUnwindcTracer_810.h>
 #include <profiler/ArtUnwindcTracer_900.h>
+#include <profiler/ArtUnwindcTracer_1000.h>
 #include <profiler/DalvikTracer.h>
 #include <profiler/ExternalTracerManager.h>
 #include <profiler/JSTracer.h>
@@ -621,6 +622,11 @@ SamplingProfiler::ComputeAvailableTracers(uint32_t available_tracers) {
   if (available_tracers & tracers::ART_UNWINDC_9_0_0) {
     tracers[tracers::ART_UNWINDC_9_0_0] =
         std::make_shared<ArtUnwindcTracer900>();
+  }
+
+  if (available_tracers & tracers::ART_UNWINDC_10_0_0) {
+    tracers[tracers::ART_UNWINDC_10_0_0] =
+        std::make_shared<ArtUnwindcTracer1000>();
   }
 
   if (available_tracers & tracers::JAVASCRIPT) {

--- a/cpp/profiler/unwindc/android_1000/arm/unwinder.h
+++ b/cpp/profiler/unwindc/android_1000/arm/unwinder.h
@@ -1,0 +1,757 @@
+// @nolint
+// @generated
+struct OatMethod {
+  uintptr_t begin_uintptr;
+  uintptr_t offset_uintptr;
+  bool success_b;
+};
+struct OatClass {
+  uintptr_t oat_file_uintptr;
+  intptr_t status_intptr;
+  uintptr_t type_uintptr;
+  uintptr_t bitmap_size_uintptr;
+  uintptr_t bitmap_ptr_uintptr;
+  uintptr_t methods_ptr_uintptr;
+  bool success_b;
+};
+struct ArraySlice {
+  uintptr_t array_uintptr;
+  uintptr_t size_uintptr;
+  uintptr_t element_size_uintptr;
+};
+
+auto get_runtime_from_thread(uintptr_t thread) {
+  uint32_t jni_env = Read4(AccessField(AccessField(thread, 152U), 28U));
+  uint32_t java_vm = Read4(AccessField(jni_env, 8U));
+  uint32_t runtime = Read4(AccessField(java_vm, 4U));
+  return runtime;
+}
+
+auto get_runtime() {
+  return get_runtime_from_thread(get_art_thread());
+}
+
+auto get_class_dexfile(uintptr_t cls) {
+  uintptr_t dexcache_heap_ref = AccessField(cls, 16U);
+  uintptr_t dexcache_ptr = AccessField(dexcache_heap_ref, 0U);
+  dexcache_ptr = Read4(AccessField(dexcache_ptr, 0U));
+  uintptr_t dexcache = dexcache_ptr;
+  uint64_t dexfile = Read8(AccessField(dexcache, 16U));
+  return dexfile;
+}
+
+auto get_dexfile_string_by_idx(uintptr_t dexfile, uintptr_t idx) {
+  idx = idx;
+  uintptr_t id = AccessArrayItem(Read4(AccessField(dexfile, 40U)), idx, 4U);
+  uint32_t begin = Read4(AccessField(dexfile, 12U));
+  uint32_t string_data_off = Read4(AccessField(id, 0U));
+  uintptr_t ptr = AdvancePointer(begin, (string_data_off * 1U));
+  uintptr_t val = ptr;
+  uintptr_t length = 0U;
+  uintptr_t index = 0U;
+  bool proceed = true;
+  while (proceed) {
+    uint8_t byte = Read1(AccessArrayItem(val, index, 1U));
+    length = (length | ((byte & 127U) << (index * 7U)));
+    proceed = ((byte & 128U) != 0U);
+    index = (index + 1U);
+  }
+  string_t result =
+      String(AdvancePointer(ptr, (index * 1U)), "ascii", "ignore", length);
+  return String(result);
+}
+
+auto get_declaring_class(uintptr_t method) {
+  uintptr_t declaring_class_gc_root = AccessField(method, 0U);
+  uintptr_t declaring_class_ref = AccessField(declaring_class_gc_root, 0U);
+  uint32_t declaring_class_ptr = Read4(AccessField(declaring_class_ref, 0U));
+  uint32_t declaring_class = declaring_class_ptr;
+  return declaring_class;
+}
+
+auto get_method_trace_id(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uintptr_t signature = AccessField(Read4(AccessField(dexfile, 36U)), 12U);
+  uint32_t dex_id = Read4(signature);
+  dex_id = dex_id;
+  uint32_t method_id = Read4(AccessField(method, 12U));
+  return GetMethodTraceId(dex_id, method_id);
+}
+
+auto get_method_name(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t dex_method_index = Read4(AccessField(method, 12U));
+  uintptr_t method_id =
+      AccessArrayItem(Read4(AccessField(dexfile, 52U)), dex_method_index, 8U);
+  uintptr_t name_idx = AccessField(method_id, 4U);
+  name_idx = Read4(AccessField(name_idx, 0U));
+  return get_dexfile_string_by_idx(dexfile, name_idx);
+}
+
+auto get_class_descriptor(uintptr_t cls) {
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t typeidx = Read4(AccessField(cls, 84U));
+  uintptr_t typeid_ =
+      AccessArrayItem(Read4(AccessField(dexfile, 44U)), typeidx, 4U);
+  uintptr_t descriptor_idx = AccessField(typeid_, 0U);
+  descriptor_idx = Read4(AccessField(descriptor_idx, 0U));
+  return get_dexfile_string_by_idx(dexfile, descriptor_idx);
+}
+
+auto get_method_shorty(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t dex_method_index = Read4(AccessField(method, 12U));
+  uintptr_t method_id =
+      AccessArrayItem(Read4(AccessField(dexfile, 52U)), dex_method_index, 8U);
+  uint16_t proto_idx = Read2(AccessField(method_id, 2U));
+  uintptr_t method_proto_id =
+      AccessArrayItem(Read4(AccessField(dexfile, 56U)), proto_idx, 12U);
+  uintptr_t shorty_id = AccessField(method_proto_id, 0U);
+  shorty_id = Read4(AccessField(shorty_id, 0U));
+  return get_dexfile_string_by_idx(dexfile, shorty_id);
+}
+
+auto get_number_of_refs_without_receiver(uintptr_t method) {
+  auto shorty = get_method_shorty(method);
+  return CountShortyRefs(shorty);
+}
+
+auto get_method_access_flags(uintptr_t method) {
+  uintptr_t access_flags = AccessField(method, 4U);
+  access_flags = Read4(AccessField(access_flags, 0U));
+  return access_flags;
+}
+
+auto is_runtime_method(uintptr_t method) {
+  uint32_t dex_method_index = Read4(AccessField(method, 12U));
+  bool is_runtime_method = (dex_method_index == 4294967295U);
+  return is_runtime_method;
+}
+
+auto is_proxy_method(uintptr_t method) {
+  auto declaring_class = get_declaring_class(method);
+  uint32_t class_access_flags = Read4(AccessField(declaring_class, 64U));
+  uintptr_t kAccClassIsProxy = 262144U;
+  if ((class_access_flags & kAccClassIsProxy)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_static_method(uintptr_t method) {
+  uintptr_t kAccStatic = 8U;
+  if ((get_method_access_flags(method) & kAccStatic)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_direct_method(uintptr_t method) {
+  uintptr_t kAccStatic = 8U;
+  uintptr_t kAccPrivate = 2U;
+  uintptr_t kAccConstructor = 65536U;
+  if ((get_method_access_flags(method) &
+       ((kAccStatic | kAccPrivate) | kAccConstructor))) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_native_method(uintptr_t method) {
+  uintptr_t kAccNative = 256U;
+  if ((get_method_access_flags(method) & kAccNative)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_quick_resolution_stub(
+    uintptr_t entry_point,
+    uintptr_t runtime,
+    uintptr_t thread) {
+  uint32_t class_linker = Read4(AccessField(runtime, 280U));
+  uintptr_t entry_points = AccessField(AccessField(thread, 152U), 156U);
+  return (
+      (Read4(AccessField(class_linker, 168U)) == entry_point) ||
+      (Read4(AccessField(entry_points, 392U)) ==
+       entry_point)); // GetQuickResolutionStub
+}
+
+auto is_quick_to_interpreter_bridge(
+    uintptr_t entry_point,
+    uintptr_t runtime,
+    uintptr_t thread) {
+  uint32_t class_linker = Read4(AccessField(runtime, 280U));
+  uintptr_t entry_points = AccessField(AccessField(thread, 152U), 156U);
+  return (
+      (Read4(AccessField(class_linker, 180U)) == entry_point) ||
+      (Read4(AccessField(entry_points, 396U)) ==
+       entry_point)); // GetQuickToInterpreterBridge
+}
+
+auto is_quick_generic_jni_stub(
+    uintptr_t entry_point,
+    uintptr_t runtime,
+    uintptr_t thread) {
+  uint32_t class_linker = Read4(AccessField(runtime, 280U));
+  uintptr_t entry_points = AccessField(AccessField(thread, 152U), 156U);
+  return (
+      (Read4(AccessField(class_linker, 176U)) == entry_point) ||
+      (Read4(AccessField(entry_points, 216U)) ==
+       entry_point)); // GetQuickGenericJniStub
+}
+
+auto get_quick_entry_point_from_compiled_code(uintptr_t method) {
+  uintptr_t ptr_fields = AccessField(method, 20U);
+  uint32_t entry_point = Read4(AccessField(ptr_fields, 4U));
+  entry_point = entry_point;
+  return entry_point;
+}
+
+auto get_oat_method_header_from_entry_point(uintptr_t entry_point) {
+  entry_point = entry_point;
+  entry_point = (entry_point & (~1U));
+  uintptr_t header_offset = 8U;
+  uintptr_t oat_method_header = (entry_point - header_offset);
+  return oat_method_header;
+}
+
+auto get_quick_frame_info_from_entry_point(uintptr_t entry_point) {
+  auto oat_method_header = get_oat_method_header_from_entry_point(entry_point);
+  return AccessField(oat_method_header, 8U);
+}
+
+auto method_header_contains(uintptr_t method_header, uintptr_t pc) {
+  uintptr_t code = AccessField(method_header, 8U);
+  uint32_t code_size = Read4(AccessField(method_header, 4U));
+  uintptr_t kCodeSizeMask = (~2147483648U);
+  code_size = (code_size & kCodeSizeMask);
+  return ((code <= pc) && (pc <= (code + code_size)));
+}
+
+auto is_resolved(uintptr_t cls) {
+  uint32_t status = Read4(AccessField(cls, 112U));
+  status = (status >> (32U - 4U));
+  uintptr_t kStatusResolved = 7U;
+  uintptr_t kStatusErrorResolved = 2U;
+  return ((status >= 4U) || (status == kStatusErrorResolved));
+}
+
+auto get_oat_class(uintptr_t oat_dex_file, uintptr_t class_def_idx) {
+  uint32_t oat_class_offsets_pointer = Read4(AccessField(oat_dex_file, 52U));
+  uintptr_t oat_class_offset =
+      AdvancePointer(oat_class_offsets_pointer, (class_def_idx * 4U));
+  oat_class_offset = Read4(oat_class_offset);
+  uint32_t oat_file = Read4(AccessField(oat_dex_file, 0U));
+  uint32_t oat_file_begin = Read4(AccessField(oat_file, 20U));
+  uintptr_t oat_class_pointer =
+      AdvancePointer(oat_file_begin, (oat_class_offset * 1U));
+
+  uintptr_t status_pointer = oat_class_pointer;
+  uint16_t status = Read2(status_pointer);
+  uintptr_t kStatusMax = 15U;
+
+  uintptr_t type_pointer = AdvancePointer(status_pointer, (2U * 1U));
+
+  uint16_t oat_type = Read2(type_pointer);
+  uintptr_t kOatClassMax = 3U;
+
+  uintptr_t after_type_pointer = AdvancePointer(type_pointer, (2U * 1U));
+
+  uintptr_t bitmap_size = 0U;
+  uintptr_t bitmap_pointer = 0U;
+  uintptr_t methods_pointer = 0U;
+  uintptr_t kOatClassNoneCompiled = 2U;
+  if ((oat_type != kOatClassNoneCompiled)) {
+    uintptr_t kOatClassSomeCompiled = 1U;
+    if ((oat_type == kOatClassSomeCompiled)) {
+      bitmap_size = Read4(after_type_pointer);
+      bitmap_pointer = AdvancePointer(after_type_pointer, (4U * 1U));
+
+      methods_pointer = AdvancePointer(bitmap_pointer, (bitmap_size * 1U));
+    } else {
+      methods_pointer = after_type_pointer;
+    }
+  }
+  return OatClass{
+      .oat_file_uintptr = oat_file,
+      .status_intptr = status,
+      .type_uintptr = oat_type,
+      .bitmap_size_uintptr = bitmap_size,
+      .bitmap_ptr_uintptr = bitmap_pointer,
+      .methods_ptr_uintptr = methods_pointer,
+      .success_b = true,
+  };
+}
+
+auto find_oat_class(uintptr_t cls) {
+  auto dex_file = get_class_dexfile(cls);
+  uint32_t class_def_idx = Read4(AccessField(cls, 80U));
+  uintptr_t kDexNoIndex16 = 65535U;
+
+  uint32_t oat_dex_file = Read4(AccessField(dex_file, 84U));
+  if (((oat_dex_file == 0U) || (Read4(AccessField(oat_dex_file, 0U)) == 0U))) {
+    return OatClass{
+        .oat_file_uintptr = 0,
+        .status_intptr = -1,
+        .type_uintptr = 2,
+        .bitmap_size_uintptr = 0,
+        .bitmap_ptr_uintptr = 0,
+        .methods_ptr_uintptr = 0,
+        .success_b = false,
+    };
+  } else {
+    return get_oat_class(oat_dex_file, class_def_idx);
+  }
+}
+
+auto count_bits_in_word(uintptr_t word) {
+  uintptr_t count = 0U;
+  while ((word > 0U)) {
+    if ((word & 1U)) {
+      count = (count + 1U);
+    }
+    word = (word >> 1U);
+  }
+  return count;
+}
+
+auto get_oat_method_offsets(
+    struct OatClass const& struct_OatClass,
+    uintptr_t method_index) {
+  uintptr_t methods_ptr = struct_OatClass.methods_ptr_uintptr;
+  uintptr_t oc_type = struct_OatClass.type_uintptr;
+  uintptr_t bitmap_ptr = struct_OatClass.bitmap_ptr_uintptr;
+  if ((methods_ptr == 0U)) {
+    uintptr_t kOatClassNoneCompiled = 2U;
+
+    return methods_ptr;
+  }
+  uintptr_t methods_pointer_index = 0U;
+  if ((bitmap_ptr == 0U)) {
+    uintptr_t kOatClassAllCompiled = 0U;
+
+    methods_pointer_index = method_index;
+  } else {
+    uintptr_t kOatClassSomeCompiled = 1U;
+
+    uintptr_t word_index = (method_index >> 5U);
+    uintptr_t bit_mask = (1U << (method_index & 31U));
+    uintptr_t is_bit_set = AdvancePointer(bitmap_ptr, (word_index * 4U));
+    is_bit_set = Read4(is_bit_set);
+    is_bit_set = ((is_bit_set & bit_mask) != 0U);
+    if ((!is_bit_set)) {
+      return is_bit_set;
+    }
+    uintptr_t word_end = (method_index >> 5U);
+    uintptr_t partial_word_bits = (method_index & 31U);
+    uintptr_t count = 0U;
+    uintptr_t word = 0U;
+    uintptr_t elem = 0U;
+    while ((word < word_end)) {
+      elem = AdvancePointer(bitmap_ptr, (word * 4U));
+      elem = Read4(elem);
+      count = (count + count_bits_in_word(elem));
+      word = (word + 1U);
+    }
+    if ((partial_word_bits != 0U)) {
+      elem = AdvancePointer(bitmap_ptr, (word_end * 4U));
+      elem = Read4(elem);
+      uint32_t shifted = 4294967295U;
+      count =
+          (count +
+           count_bits_in_word((elem & (~(shifted << partial_word_bits)))));
+    }
+    methods_pointer_index = count;
+  }
+  uintptr_t ret = AdvancePointer(methods_ptr, (methods_pointer_index * 4U));
+  return ret;
+}
+
+auto runtime_is_aot_compiler(uintptr_t runtime, uintptr_t instance) {
+  uint32_t jit =
+      Read4(AccessField(AccessField(AccessField(runtime, 292U), 0U), 0U));
+  bool use_jit_compilation =
+      ((jit != 0U) && Read1(AccessFieldDesc(jit, 96416U)));
+  uint32_t compiler_callbacks = Read4(AccessField(runtime, 84U));
+  return ((!use_jit_compilation) && (compiler_callbacks != 0U));
+}
+
+auto get_oat_method(
+    uintptr_t runtime_obj,
+    struct OatClass const& struct_OatClass,
+    uintptr_t oat_method_index) {
+  auto oat_method_offsets =
+      get_oat_method_offsets(struct_OatClass, oat_method_index);
+  if ((oat_method_offsets == 0U)) {
+    return OatMethod{
+        .begin_uintptr = 0,
+        .offset_uintptr = 0,
+        .success_b = true,
+    };
+  }
+  uintptr_t runtime_current = get_runtime();
+  uintptr_t begin_uintptr = 0U;
+  uintptr_t oat_file = struct_OatClass.oat_file_uintptr;
+  if ((Read1(AccessField(oat_file, 52U)) ||
+       ((runtime_current == 0U) ||
+        runtime_is_aot_compiler(runtime_current, runtime_current)))) {
+    begin_uintptr = Read4(AccessField(oat_file, 20U));
+    uint32_t offset_uintptr = Read4(AccessField(oat_method_offsets, 0U));
+    return OatMethod{
+        .begin_uintptr = begin_uintptr,
+        .offset_uintptr = offset_uintptr,
+        .success_b = true,
+    };
+  }
+  begin_uintptr = Read4(AccessField(oat_file, 20U));
+  return OatMethod{
+      .begin_uintptr = begin_uintptr,
+      .offset_uintptr = 0,
+      .success_b = true,
+  };
+}
+
+auto round_up(uintptr_t x, uintptr_t n) {
+  uintptr_t arg1 = ((x + n) - 1U);
+  uintptr_t arg2 = n;
+  return (arg1 & (-arg2));
+}
+
+auto length_prefixed_array_at(
+    uintptr_t array,
+    uintptr_t idx,
+    uintptr_t element_size,
+    uintptr_t alignment) {
+  uintptr_t ptr = array;
+
+  uintptr_t data_offset = 4U;
+  auto element_offset = round_up(data_offset, alignment);
+  element_offset = (element_offset + (idx * element_size));
+  uintptr_t ret = (ptr + element_offset);
+  return ret;
+}
+
+auto get_virtual_methods(
+    uintptr_t method,
+    uintptr_t cls,
+    uintptr_t start_offset) {
+  uintptr_t ptr_size = 4U;
+  uintptr_t num_methods = 0U;
+  uint64_t methods_ptr = Read8(AccessField(cls, 48U));
+  if ((methods_ptr == 0U)) {
+    num_methods = 0U;
+  } else {
+    num_methods = Read4(AccessField(methods_ptr, 0U));
+  }
+  uintptr_t end_offset = num_methods;
+
+  uintptr_t size = (end_offset - start_offset);
+  if ((size == 0U)) {
+    return ArraySlice{
+        .array_uintptr = 0,
+        .size_uintptr = 0,
+        .element_size_uintptr = 0,
+    };
+  }
+
+  uintptr_t method_size = 20U;
+  method_size = round_up(method_size, ptr_size);
+  method_size = (method_size + 8U);
+  uintptr_t method_alignment = ptr_size;
+  auto array_method =
+      length_prefixed_array_at(methods_ptr, 0U, method_size, method_alignment);
+  uint32_t size_uintptr = Read4(AccessField(methods_ptr, 0U));
+  auto array_slice = ArraySlice{
+      .array_uintptr = array_method,
+      .size_uintptr = size_uintptr,
+      .element_size_uintptr = method_size,
+  };
+
+  uintptr_t tmp = array_slice.array_uintptr;
+  tmp = (tmp + (start_offset * array_slice.element_size_uintptr));
+  return ArraySlice{
+      .array_uintptr = tmp,
+      .size_uintptr = size,
+      .element_size_uintptr = array_slice.element_size_uintptr,
+  };
+}
+
+auto find_oat_method_for(uintptr_t method, uintptr_t runtime_obj) {
+  uintptr_t oat_method_index = 0U;
+  auto cls = get_declaring_class(method); // done
+  if ((is_static_method(method) || is_direct_method(method))) {
+    oat_method_index = Read2(AccessField(method, 16U));
+  } else {
+    oat_method_index = Read2(AccessField(cls, 118U));
+    auto virtual_methods = get_virtual_methods(method, cls, oat_method_index);
+    uintptr_t iterator = virtual_methods.array_uintptr;
+    uintptr_t end =
+        (iterator +
+         (virtual_methods.size_uintptr * virtual_methods.element_size_uintptr));
+    bool found_virtual = false;
+    while ((iterator != end)) {
+      uintptr_t art_method = iterator;
+      if ((Read4(AccessField(art_method, 12U)) ==
+           Read4(AccessField(method, 12U)))) {
+        found_virtual = true;
+        break;
+      }
+      oat_method_index = (oat_method_index + 1U);
+      iterator = (iterator + virtual_methods.element_size_uintptr);
+    }
+  }
+  auto oat_class = find_oat_class(cls);
+  if ((!oat_class.success_b)) {
+    return OatMethod{
+        .begin_uintptr = 0,
+        .offset_uintptr = 0,
+        .success_b = false,
+    };
+  }
+  return get_oat_method(runtime_obj, oat_class, oat_method_index);
+}
+
+auto get_oat_pointer(
+    struct OatMethod const& struct_OatMethod,
+    uintptr_t offset) {
+  if ((offset == 0U)) {
+    return offset;
+  }
+  uintptr_t begin = struct_OatMethod.begin_uintptr;
+  return AdvancePointer(begin, (offset * 1U));
+}
+
+auto get_code_offset(struct OatMethod const& struct_OatMethod) {
+  uintptr_t oat_method_offset = struct_OatMethod.offset_uintptr;
+  auto code =
+      get_oat_pointer(struct_OatMethod, oat_method_offset); // GetOatPointer
+  code = (code & (~1U)); // EntryPointToCodePointer
+  if ((code == 0U)) {
+    return 0U;
+  }
+  uintptr_t method_header_size = 8U;
+  code = (code - method_header_size);
+  uintptr_t kCodeSizeMask = (~2147483648U);
+  uint32_t code_size = Read4(AccessField(code, 4U));
+  code_size = (code_size & kCodeSizeMask);
+  if ((code_size == 0U)) {
+    return 0U;
+  }
+  return (unsigned int)oat_method_offset;
+}
+
+auto get_quick_code(struct OatMethod const& struct_OatMethod) {
+  auto offset = get_code_offset(struct_OatMethod);
+  auto quick_code = get_oat_pointer(struct_OatMethod, offset);
+  return quick_code;
+}
+
+auto get_oat_quick_method_header(
+    uintptr_t method,
+    uintptr_t runtime_obj,
+    uintptr_t thread_obj,
+    uintptr_t pc) {
+  if (is_runtime_method(method)) {
+    return 0U;
+  }
+  auto existing_entry_point = get_quick_entry_point_from_compiled_code(method);
+  uintptr_t method_header = 0U;
+  if (((!is_quick_generic_jni_stub(
+           existing_entry_point, runtime_obj, thread_obj)) &&
+       (!is_quick_resolution_stub(
+           existing_entry_point, runtime_obj, thread_obj)) &&
+       (!is_quick_to_interpreter_bridge(
+           existing_entry_point, runtime_obj, thread_obj)))) {
+    auto entry_point_tmp = existing_entry_point;
+    method_header = get_oat_method_header_from_entry_point(entry_point_tmp);
+    bool ret = method_header_contains(method_header, pc);
+    if (ret) {
+      return (unsigned int)method_header;
+    }
+  }
+  auto oat_method = find_oat_method_for(method, runtime_obj);
+  if ((!oat_method.success_b)) {
+    if (is_quick_resolution_stub(
+            existing_entry_point, runtime_obj, thread_obj)) {
+      return 0U;
+    }
+  }
+  auto oat_entry_point = get_quick_code(oat_method);
+  if (((oat_entry_point == 0U) ||
+       is_quick_generic_jni_stub(oat_entry_point, runtime_obj, thread_obj))) {
+    return 0U;
+  }
+  oat_entry_point = oat_entry_point;
+  method_header = get_oat_method_header_from_entry_point(oat_entry_point);
+  if ((pc == 0U)) {
+    return (unsigned int)method_header;
+  }
+  return (unsigned int)method_header;
+}
+
+auto is_abstract_method(uintptr_t method) {
+  uintptr_t kAccAbstract = 1024U;
+  return (get_method_access_flags(method) & kAccAbstract);
+}
+
+uintptr_t read_variant_size(uintptr_t code_info_ptr) {
+  uintptr_t tmp = code_info_ptr & 0x0F;
+  uint32_t kVarintSmallValue = 11;
+  uint32_t kali = 11;
+  size_t kStackAlignment = 16;
+  if (tmp > kVarintSmallValue) {
+    return (code_info_ptr >> 4 & 0x0F) * kStackAlignment;
+  } else {
+    return tmp * kStackAlignment;
+  }
+}
+
+auto get_frame_size(
+    uintptr_t frameptr,
+    uintptr_t runtime_obj,
+    uintptr_t thread_obj,
+    uintptr_t pc) {
+  uintptr_t method = frameptr;
+  auto entry_point = get_quick_entry_point_from_compiled_code(method);
+  auto oat_quick_method_header =
+      get_oat_quick_method_header(method, runtime_obj, thread_obj, pc);
+  if ((oat_quick_method_header != 0U)) {
+    uint32_t vmap_table_offset =
+        Read4(AccessField(oat_quick_method_header, 0U));
+    uintptr_t code_info_ptr = Read4(AccessFieldDesc(
+        AccessField(oat_quick_method_header, 8U), vmap_table_offset));
+    uintptr_t frame_size = read_variant_size(code_info_ptr);
+    return (unsigned int)frame_size;
+  }
+  uint32_t size = 0U;
+  uintptr_t callee_save_methods = AccessField(runtime_obj, 0U);
+  uintptr_t kSaveAll = 0U;
+  uintptr_t kRefsOnly = 1U;
+  uintptr_t kRefsAndArgs = 2U;
+  uintptr_t method_info = 0U;
+  if (is_abstract_method(method)) {
+    return 112U;
+  }
+  if (is_runtime_method(method)) {
+    if ((frameptr ==
+         Read8(AccessArrayItem(callee_save_methods, kRefsAndArgs, 8U)))) {
+      return 112U;
+    } else {
+      if ((frameptr ==
+           Read8(AccessArrayItem(callee_save_methods, kSaveAll, 8U)))) {
+        return 88U;
+      } else {
+        return 48U;
+      }
+    }
+    size = Read4(AccessField(method_info, 0U));
+    return size;
+  }
+  if (is_proxy_method(method)) {
+    if (is_direct_method(method)) {
+      auto info = get_quick_frame_info_from_entry_point(entry_point);
+      size = Read4(AccessField(info, 0U));
+      return size;
+    } else {
+      return 112U;
+    }
+  }
+  uintptr_t code = 0U;
+  bool is_native = false;
+  if ((is_quick_resolution_stub(entry_point, runtime_obj, thread_obj) ||
+       is_quick_to_interpreter_bridge(entry_point, runtime_obj, thread_obj))) {
+    if (is_native_method(method)) {
+      is_native = true;
+    } else {
+    }
+  }
+  code = entry_point;
+  if ((is_native || is_quick_generic_jni_stub(code, runtime_obj, thread_obj))) {
+    uint32_t callee_info_size = 112U;
+    uintptr_t voidptr_size = 8U;
+    uintptr_t artmethodptr_size = 8U;
+    auto num_refs = (get_number_of_refs_without_receiver(method) + 1U);
+    uintptr_t handle_scope_size = (12U + (4U * num_refs));
+    size =
+        (((callee_info_size - voidptr_size) + artmethodptr_size) +
+         handle_scope_size);
+    uintptr_t kStackAlignment = 16U;
+    size = round_up(size, kStackAlignment);
+    return size;
+  }
+  auto frame_info = get_quick_frame_info_from_entry_point(code);
+  size = Read4(AccessField(frame_info, 0U));
+  return size;
+}
+
+auto unwind(unwind_callback_t __unwind_callback, void* __unwind_data) {
+  uintptr_t thread = get_art_thread();
+  if ((thread == 0U)) {
+    return true;
+  }
+  auto runtime = get_runtime_from_thread(thread);
+  uintptr_t thread_obj = thread;
+  auto runtime_obj = runtime;
+  uintptr_t tls = AccessField(thread_obj, 152U);
+  uintptr_t mstack = AccessField(tls, 12U);
+  while ((mstack != 0U)) {
+    uint32_t quick_frame =
+        (Read4(AccessField(AccessField(mstack, 0U), 0U)) & (~1U));
+    quick_frame = quick_frame;
+    uint32_t shadow_frame = Read4(AccessField(mstack, 8U));
+    shadow_frame = shadow_frame;
+    uintptr_t pc = 0U;
+    uintptr_t kMaxFrames = 1024U;
+    uintptr_t depth = 0U;
+    if ((quick_frame != 0U)) {
+      while (((quick_frame != 0U) && (depth < kMaxFrames))) {
+        uint32_t frameptr = Read4(quick_frame);
+        if ((frameptr == 0U)) {
+          break;
+        }
+        uint32_t frame = frameptr;
+        if ((!is_runtime_method(frame))) {
+          if ((!__unwind_callback(frame, __unwind_data))) {
+            return false;
+          }
+        }
+        auto size = get_frame_size(frameptr, runtime_obj, thread_obj, pc);
+        auto return_pc_offset = (size - 4U);
+        uint32_t return_pc_addr = (quick_frame + return_pc_offset);
+        uint32_t return_pc = return_pc_addr;
+        pc = Read4(return_pc);
+        quick_frame = (quick_frame + size);
+        depth = (depth + 1U);
+      }
+    } else {
+      if ((shadow_frame != 0U)) {
+        while (((shadow_frame != 0U) && (depth < kMaxFrames))) {
+          uint32_t frame_obj = shadow_frame;
+          uint32_t artmethodptr = Read4(AccessField(frame_obj, 4U));
+          uint32_t artmethod = artmethodptr;
+          if ((!is_runtime_method(artmethod))) {
+            if ((!__unwind_callback(artmethod, __unwind_data))) {
+              return false;
+            }
+          }
+          shadow_frame = Read4(AccessField(frame_obj, 0U));
+          depth = (depth + 1U);
+        }
+      }
+    }
+    uint32_t link = Read4(AccessField(mstack, 4U));
+    if ((link == 0U)) {
+      break;
+    }
+    mstack = link;
+  }
+  return true;
+}

--- a/cpp/profiler/unwindc/android_1000/arm64/unwinder.h
+++ b/cpp/profiler/unwindc/android_1000/arm64/unwinder.h
@@ -1,0 +1,758 @@
+// @nolint
+// @generated
+struct OatMethod {
+  uintptr_t begin_uintptr;
+  uintptr_t offset_uintptr;
+  bool success_b;
+};
+struct OatClass {
+  uintptr_t oat_file_uintptr;
+  intptr_t status_intptr;
+  uintptr_t type_uintptr;
+  uintptr_t bitmap_size_uintptr;
+  uintptr_t bitmap_ptr_uintptr;
+  uintptr_t methods_ptr_uintptr;
+  bool success_b;
+};
+struct ArraySlice {
+  uintptr_t array_uintptr;
+  uintptr_t size_uintptr;
+  uintptr_t element_size_uintptr;
+};
+
+auto get_runtime_from_thread(uintptr_t thread) {
+  uint64_t jni_env = Read8(AccessField(AccessField(thread, 152UL), 56UL));
+  uint64_t java_vm = Read8(AccessField(jni_env, 16UL));
+  uint64_t runtime = Read8(AccessField(java_vm, 8UL));
+  return runtime;
+}
+
+auto get_runtime() {
+  return get_runtime_from_thread(get_art_thread());
+}
+
+auto get_class_dexfile(uintptr_t cls) {
+  uintptr_t dexcache_heap_ref = AccessField(cls, 16UL);
+  uintptr_t dexcache_ptr = AccessField(dexcache_heap_ref, 0UL);
+  dexcache_ptr = Read4(AccessField(dexcache_ptr, 0UL));
+  uintptr_t dexcache = dexcache_ptr;
+  uint64_t dexfile = Read8(AccessField(dexcache, 16UL));
+  return dexfile;
+}
+
+auto get_dexfile_string_by_idx(uintptr_t dexfile, uintptr_t idx) {
+  idx = idx;
+  uintptr_t id = AccessArrayItem(Read8(AccessField(dexfile, 80UL)), idx, 4UL);
+  uint64_t begin = Read8(AccessField(dexfile, 24UL));
+  uint32_t string_data_off = Read4(AccessField(id, 0UL));
+  uintptr_t ptr = AdvancePointer(begin, (string_data_off * 1UL));
+  uintptr_t val = ptr;
+  uintptr_t length = 0UL;
+  uintptr_t index = 0UL;
+  bool proceed = true;
+  while (proceed) {
+    uint8_t byte = Read1(AccessArrayItem(val, index, 1UL));
+    length = (length | ((byte & 127UL) << (index * 7UL)));
+    proceed = ((byte & 128UL) != 0UL);
+    index = (index + 1UL);
+  }
+  string_t result =
+      String(AdvancePointer(ptr, (index * 1UL)), "ascii", "ignore", length);
+  return String(result);
+}
+
+auto get_declaring_class(uintptr_t method) {
+  uintptr_t declaring_class_gc_root = AccessField(method, 0UL);
+  uintptr_t declaring_class_ref = AccessField(declaring_class_gc_root, 0UL);
+  uint32_t declaring_class_ptr = Read4(AccessField(declaring_class_ref, 0UL));
+  uint32_t declaring_class = declaring_class_ptr;
+  return declaring_class;
+}
+
+auto get_method_trace_id(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uintptr_t signature = AccessField(Read8(AccessField(dexfile, 72UL)), 12UL);
+  uint32_t dex_id = Read4(signature);
+  dex_id = dex_id;
+  uint32_t method_id = Read4(AccessField(method, 12UL));
+  return GetMethodTraceId(dex_id, method_id);
+}
+
+auto get_method_name(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t dex_method_index = Read4(AccessField(method, 12UL));
+  uintptr_t method_id = AccessArrayItem(
+      Read8(AccessField(dexfile, 104UL)), dex_method_index, 8UL);
+  uintptr_t name_idx = AccessField(method_id, 4UL);
+  name_idx = Read4(AccessField(name_idx, 0UL));
+  return get_dexfile_string_by_idx(dexfile, name_idx);
+}
+
+auto get_class_descriptor(uintptr_t cls) {
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t typeidx = Read4(AccessField(cls, 84UL));
+  uintptr_t typeid_ =
+      AccessArrayItem(Read8(AccessField(dexfile, 88UL)), typeidx, 4UL);
+  uintptr_t descriptor_idx = AccessField(typeid_, 0UL);
+  descriptor_idx = Read4(AccessField(descriptor_idx, 0UL));
+  return get_dexfile_string_by_idx(dexfile, descriptor_idx);
+}
+
+auto get_method_shorty(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t dex_method_index = Read4(AccessField(method, 12UL));
+  uintptr_t method_id = AccessArrayItem(
+      Read8(AccessField(dexfile, 104UL)), dex_method_index, 8UL);
+  uint16_t proto_idx = Read2(AccessField(method_id, 2UL));
+  uintptr_t method_proto_id =
+      AccessArrayItem(Read8(AccessField(dexfile, 112UL)), proto_idx, 12UL);
+  uintptr_t shorty_id = AccessField(method_proto_id, 0UL);
+  shorty_id = Read4(AccessField(shorty_id, 0UL));
+  return get_dexfile_string_by_idx(dexfile, shorty_id);
+}
+
+auto get_number_of_refs_without_receiver(uintptr_t method) {
+  auto shorty = get_method_shorty(method);
+  return CountShortyRefs(shorty);
+}
+
+auto get_method_access_flags(uintptr_t method) {
+  uintptr_t access_flags = AccessField(method, 4UL);
+  access_flags = Read4(AccessField(access_flags, 0UL));
+  return access_flags;
+}
+
+auto is_runtime_method(uintptr_t method) {
+  uint32_t dex_method_index = Read4(AccessField(method, 12UL));
+  bool is_runtime_method = (dex_method_index == 4294967295UL);
+  return is_runtime_method;
+}
+
+auto is_proxy_method(uintptr_t method) {
+  auto declaring_class = get_declaring_class(method);
+  uint32_t class_access_flags = Read4(AccessField(declaring_class, 64UL));
+  uintptr_t kAccClassIsProxy = 262144UL;
+  if ((class_access_flags & kAccClassIsProxy)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_static_method(uintptr_t method) {
+  uintptr_t kAccStatic = 8UL;
+  if ((get_method_access_flags(method) & kAccStatic)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_direct_method(uintptr_t method) {
+  uintptr_t kAccStatic = 8UL;
+  uintptr_t kAccPrivate = 2UL;
+  uintptr_t kAccConstructor = 65536UL;
+  if ((get_method_access_flags(method) &
+       ((kAccStatic | kAccPrivate) | kAccConstructor))) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_native_method(uintptr_t method) {
+  uintptr_t kAccNative = 256UL;
+  if ((get_method_access_flags(method) & kAccNative)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_quick_resolution_stub(
+    uintptr_t entry_point,
+    uintptr_t runtime,
+    uintptr_t thread) {
+  uint64_t class_linker = Read8(AccessField(runtime, 480UL));
+  uintptr_t entry_points = AccessField(AccessField(thread, 152UL), 312UL);
+  return (
+      (Read8(AccessField(class_linker, 264UL)) == entry_point) ||
+      (Read8(AccessField(entry_points, 784UL)) ==
+       entry_point)); // GetQuickResolutionStub
+}
+
+auto is_quick_to_interpreter_bridge(
+    uintptr_t entry_point,
+    uintptr_t runtime,
+    uintptr_t thread) {
+  uint64_t class_linker = Read8(AccessField(runtime, 480UL));
+  uintptr_t entry_points = AccessField(AccessField(thread, 152UL), 312UL);
+  return (
+      (Read8(AccessField(class_linker, 288UL)) == entry_point) ||
+      (Read8(AccessField(entry_points, 792UL)) ==
+       entry_point)); // GetQuickToInterpreterBridge
+}
+
+auto is_quick_generic_jni_stub(
+    uintptr_t entry_point,
+    uintptr_t runtime,
+    uintptr_t thread) {
+  uint64_t class_linker = Read8(AccessField(runtime, 480UL));
+  uintptr_t entry_points = AccessField(AccessField(thread, 152UL), 312UL);
+  return (
+      (Read8(AccessField(class_linker, 280UL)) == entry_point) ||
+      (Read8(AccessField(entry_points, 432UL)) ==
+       entry_point)); // GetQuickGenericJniStub
+}
+
+auto get_quick_entry_point_from_compiled_code(uintptr_t method) {
+  uintptr_t ptr_fields = AccessField(method, 24UL);
+  uint64_t entry_point = Read8(AccessField(ptr_fields, 8UL));
+  entry_point = entry_point;
+  return entry_point;
+}
+
+auto get_oat_method_header_from_entry_point(uintptr_t entry_point) {
+  entry_point = entry_point;
+  entry_point = (entry_point & (~1UL));
+  uintptr_t header_offset = 8UL;
+  uintptr_t oat_method_header = (entry_point - header_offset);
+  return oat_method_header;
+}
+
+auto get_quick_frame_info_from_entry_point(uintptr_t entry_point) {
+  auto oat_method_header = get_oat_method_header_from_entry_point(entry_point);
+  return AccessField(oat_method_header, 8UL);
+}
+
+auto method_header_contains(uintptr_t method_header, uintptr_t pc) {
+  uintptr_t code = AccessField(method_header, 8UL);
+  uint32_t code_size = Read4(AccessField(method_header, 4UL));
+  uintptr_t kCodeSizeMask = (~2147483648UL);
+  code_size = (code_size & kCodeSizeMask);
+  return ((code <= pc) && (pc <= (code + code_size)));
+}
+
+auto is_resolved(uintptr_t cls) {
+  uint32_t status = Read4(AccessField(cls, 112UL));
+  status = (status >> (32UL - 4UL));
+  uintptr_t kStatusResolved = 7UL;
+  uintptr_t kStatusErrorResolved = 2UL;
+  return ((status >= 4UL) || (status == kStatusErrorResolved));
+}
+
+auto get_oat_class(uintptr_t oat_dex_file, uintptr_t class_def_idx) {
+  uint64_t oat_class_offsets_pointer = Read8(AccessField(oat_dex_file, 104UL));
+  uintptr_t oat_class_offset =
+      AdvancePointer(oat_class_offsets_pointer, (class_def_idx * 4UL));
+  oat_class_offset = Read4(oat_class_offset);
+  uint64_t oat_file = Read8(AccessField(oat_dex_file, 0UL));
+  uint64_t oat_file_begin = Read8(AccessField(oat_file, 40UL));
+  uintptr_t oat_class_pointer =
+      AdvancePointer(oat_file_begin, (oat_class_offset * 1UL));
+
+  uintptr_t status_pointer = oat_class_pointer;
+  uint16_t status = Read2(status_pointer);
+  uintptr_t kStatusMax = 15UL;
+
+  uintptr_t type_pointer = AdvancePointer(status_pointer, (2UL * 1UL));
+
+  uint16_t oat_type = Read2(type_pointer);
+  uintptr_t kOatClassMax = 3UL;
+
+  uintptr_t after_type_pointer = AdvancePointer(type_pointer, (2UL * 1UL));
+
+  uintptr_t bitmap_size = 0UL;
+  uintptr_t bitmap_pointer = 0UL;
+  uintptr_t methods_pointer = 0UL;
+  uintptr_t kOatClassNoneCompiled = 2UL;
+  if ((oat_type != kOatClassNoneCompiled)) {
+    uintptr_t kOatClassSomeCompiled = 1UL;
+    if ((oat_type == kOatClassSomeCompiled)) {
+      bitmap_size = Read4(after_type_pointer);
+      bitmap_pointer = AdvancePointer(after_type_pointer, (4UL * 1UL));
+
+      methods_pointer = AdvancePointer(bitmap_pointer, (bitmap_size * 1UL));
+    } else {
+      methods_pointer = after_type_pointer;
+    }
+  }
+  return OatClass{
+      .oat_file_uintptr = oat_file,
+      .status_intptr = status,
+      .type_uintptr = oat_type,
+      .bitmap_size_uintptr = bitmap_size,
+      .bitmap_ptr_uintptr = bitmap_pointer,
+      .methods_ptr_uintptr = methods_pointer,
+      .success_b = true,
+  };
+}
+
+auto find_oat_class(uintptr_t cls) {
+  auto dex_file = get_class_dexfile(cls);
+  uint32_t class_def_idx = Read4(AccessField(cls, 80UL));
+  uintptr_t kDexNoIndex16 = 65535UL;
+
+  uint64_t oat_dex_file = Read8(AccessField(dex_file, 168UL));
+  if (((oat_dex_file == 0UL) ||
+       (Read8(AccessField(oat_dex_file, 0UL)) == 0UL))) {
+    return OatClass{
+        .oat_file_uintptr = 0,
+        .status_intptr = -1,
+        .type_uintptr = 2,
+        .bitmap_size_uintptr = 0,
+        .bitmap_ptr_uintptr = 0,
+        .methods_ptr_uintptr = 0,
+        .success_b = false,
+    };
+  } else {
+    return get_oat_class(oat_dex_file, class_def_idx);
+  }
+}
+
+auto count_bits_in_word(uintptr_t word) {
+  uintptr_t count = 0UL;
+  while ((word > 0UL)) {
+    if ((word & 1UL)) {
+      count = (count + 1UL);
+    }
+    word = (word >> 1UL);
+  }
+  return count;
+}
+
+auto get_oat_method_offsets(
+    struct OatClass const& struct_OatClass,
+    uintptr_t method_index) {
+  uintptr_t methods_ptr = struct_OatClass.methods_ptr_uintptr;
+  uintptr_t oc_type = struct_OatClass.type_uintptr;
+  uintptr_t bitmap_ptr = struct_OatClass.bitmap_ptr_uintptr;
+  if ((methods_ptr == 0UL)) {
+    uintptr_t kOatClassNoneCompiled = 2UL;
+
+    return methods_ptr;
+  }
+  uintptr_t methods_pointer_index = 0UL;
+  if ((bitmap_ptr == 0UL)) {
+    uintptr_t kOatClassAllCompiled = 0UL;
+
+    methods_pointer_index = method_index;
+  } else {
+    uintptr_t kOatClassSomeCompiled = 1UL;
+
+    uintptr_t word_index = (method_index >> 5UL);
+    uintptr_t bit_mask = (1UL << (method_index & 31UL));
+    uintptr_t is_bit_set = AdvancePointer(bitmap_ptr, (word_index * 4UL));
+    is_bit_set = Read4(is_bit_set);
+    is_bit_set = ((is_bit_set & bit_mask) != 0UL);
+    if ((!is_bit_set)) {
+      return is_bit_set;
+    }
+    uintptr_t word_end = (method_index >> 5UL);
+    uintptr_t partial_word_bits = (method_index & 31UL);
+    uintptr_t count = 0UL;
+    uintptr_t word = 0UL;
+    uintptr_t elem = 0UL;
+    while ((word < word_end)) {
+      elem = AdvancePointer(bitmap_ptr, (word * 4UL));
+      elem = Read4(elem);
+      count = (count + count_bits_in_word(elem));
+      word = (word + 1UL);
+    }
+    if ((partial_word_bits != 0UL)) {
+      elem = AdvancePointer(bitmap_ptr, (word_end * 4UL));
+      elem = Read4(elem);
+      uint32_t shifted = 4294967295U;
+      count =
+          (count +
+           count_bits_in_word((elem & (~(shifted << partial_word_bits)))));
+    }
+    methods_pointer_index = count;
+  }
+  uintptr_t ret = AdvancePointer(methods_ptr, (methods_pointer_index * 4UL));
+  return ret;
+}
+
+auto runtime_is_aot_compiler(uintptr_t runtime, uintptr_t instance) {
+  uint64_t jit =
+      Read8(AccessField(AccessField(AccessField(runtime, 504UL), 0UL), 0UL));
+  bool use_jit_compilation =
+      ((jit != 0UL) && Read1(AccessFieldDesc(jit, 58640UL)));
+  uint64_t compiler_callbacks = Read8(AccessField(runtime, 96UL));
+  return ((!use_jit_compilation) && (compiler_callbacks != 0UL));
+}
+
+auto get_oat_method(
+    uintptr_t runtime_obj,
+    struct OatClass const& struct_OatClass,
+    uintptr_t oat_method_index) {
+  auto oat_method_offsets =
+      get_oat_method_offsets(struct_OatClass, oat_method_index);
+  if ((oat_method_offsets == 0UL)) {
+    return OatMethod{
+        .begin_uintptr = 0,
+        .offset_uintptr = 0,
+        .success_b = true,
+    };
+  }
+  uintptr_t runtime_current = get_runtime();
+  uintptr_t begin_uintptr = 0UL;
+  uintptr_t oat_file = struct_OatClass.oat_file_uintptr;
+  if ((Read1(AccessField(oat_file, 104UL)) ||
+       ((runtime_current == 0UL) ||
+        runtime_is_aot_compiler(runtime_current, runtime_current)))) {
+    begin_uintptr = Read8(AccessField(oat_file, 40UL));
+    uint32_t offset_uintptr = Read4(AccessField(oat_method_offsets, 0UL));
+    return OatMethod{
+        .begin_uintptr = begin_uintptr,
+        .offset_uintptr = offset_uintptr,
+        .success_b = true,
+    };
+  }
+  begin_uintptr = Read8(AccessField(oat_file, 40UL));
+  return OatMethod{
+      .begin_uintptr = begin_uintptr,
+      .offset_uintptr = 0,
+      .success_b = true,
+  };
+}
+
+auto round_up(uintptr_t x, uintptr_t n) {
+  uintptr_t arg1 = ((x + n) - 1UL);
+  uintptr_t arg2 = n;
+  return (arg1 & (-arg2));
+}
+
+auto length_prefixed_array_at(
+    uintptr_t array,
+    uintptr_t idx,
+    uintptr_t element_size,
+    uintptr_t alignment) {
+  uintptr_t ptr = array;
+
+  uintptr_t data_offset = 4UL;
+  auto element_offset = round_up(data_offset, alignment);
+  element_offset = (element_offset + (idx * element_size));
+  uintptr_t ret = (ptr + element_offset);
+  return ret;
+}
+
+auto get_virtual_methods(
+    uintptr_t method,
+    uintptr_t cls,
+    uintptr_t start_offset) {
+  uintptr_t ptr_size = 8UL;
+  uintptr_t num_methods = 0UL;
+  uint64_t methods_ptr = Read8(AccessField(cls, 48UL));
+  if ((methods_ptr == 0UL)) {
+    num_methods = 0UL;
+  } else {
+    num_methods = Read4(AccessField(methods_ptr, 0UL));
+  }
+  uintptr_t end_offset = num_methods;
+
+  uintptr_t size = (end_offset - start_offset);
+  if ((size == 0UL)) {
+    return ArraySlice{
+        .array_uintptr = 0,
+        .size_uintptr = 0,
+        .element_size_uintptr = 0,
+    };
+  }
+
+  uintptr_t method_size = 24UL;
+  method_size = round_up(method_size, ptr_size);
+  method_size = (method_size + 16UL);
+  uintptr_t method_alignment = ptr_size;
+  auto array_method =
+      length_prefixed_array_at(methods_ptr, 0UL, method_size, method_alignment);
+  uint32_t size_uintptr = Read4(AccessField(methods_ptr, 0UL));
+  auto array_slice = ArraySlice{
+      .array_uintptr = array_method,
+      .size_uintptr = size_uintptr,
+      .element_size_uintptr = method_size,
+  };
+
+  uintptr_t tmp = array_slice.array_uintptr;
+  tmp = (tmp + (start_offset * array_slice.element_size_uintptr));
+  return ArraySlice{
+      .array_uintptr = tmp,
+      .size_uintptr = size,
+      .element_size_uintptr = array_slice.element_size_uintptr,
+  };
+}
+
+auto find_oat_method_for(uintptr_t method, uintptr_t runtime_obj) {
+  uintptr_t oat_method_index = 0UL;
+  auto cls = get_declaring_class(method); // done
+  if ((is_static_method(method) || is_direct_method(method))) {
+    oat_method_index = Read2(AccessField(method, 16UL));
+  } else {
+    oat_method_index = Read2(AccessField(cls, 118UL));
+    auto virtual_methods = get_virtual_methods(method, cls, oat_method_index);
+    uintptr_t iterator = virtual_methods.array_uintptr;
+    uintptr_t end =
+        (iterator +
+         (virtual_methods.size_uintptr * virtual_methods.element_size_uintptr));
+    bool found_virtual = false;
+    while ((iterator != end)) {
+      uintptr_t art_method = iterator;
+      if ((Read4(AccessField(art_method, 12UL)) ==
+           Read4(AccessField(method, 12UL)))) {
+        found_virtual = true;
+        break;
+      }
+      oat_method_index = (oat_method_index + 1UL);
+      iterator = (iterator + virtual_methods.element_size_uintptr);
+    }
+  }
+  auto oat_class = find_oat_class(cls);
+  if ((!oat_class.success_b)) {
+    return OatMethod{
+        .begin_uintptr = 0,
+        .offset_uintptr = 0,
+        .success_b = false,
+    };
+  }
+  return get_oat_method(runtime_obj, oat_class, oat_method_index);
+}
+
+auto get_oat_pointer(
+    struct OatMethod const& struct_OatMethod,
+    uintptr_t offset) {
+  if ((offset == 0UL)) {
+    return offset;
+  }
+  uintptr_t begin = struct_OatMethod.begin_uintptr;
+  return AdvancePointer(begin, (offset * 1UL));
+}
+
+auto get_code_offset(struct OatMethod const& struct_OatMethod) {
+  uintptr_t oat_method_offset = struct_OatMethod.offset_uintptr;
+  auto code =
+      get_oat_pointer(struct_OatMethod, oat_method_offset); // GetOatPointer
+  code = (code & (~1UL)); // EntryPointToCodePointer
+  if ((code == 0UL)) {
+    return 0UL;
+  }
+  uintptr_t method_header_size = 8UL;
+  code = (code - method_header_size);
+  uintptr_t kCodeSizeMask = (~2147483648UL);
+  uint32_t code_size = Read4(AccessField(code, 4UL));
+  code_size = (code_size & kCodeSizeMask);
+  if ((code_size == 0UL)) {
+    return 0UL;
+  }
+  return (unsigned long)oat_method_offset;
+}
+
+auto get_quick_code(struct OatMethod const& struct_OatMethod) {
+  auto offset = get_code_offset(struct_OatMethod);
+  auto quick_code = get_oat_pointer(struct_OatMethod, offset);
+  return quick_code;
+}
+
+auto get_oat_quick_method_header(
+    uintptr_t method,
+    uintptr_t runtime_obj,
+    uintptr_t thread_obj,
+    uintptr_t pc) {
+  if (is_runtime_method(method)) {
+    return 0UL;
+  }
+  auto existing_entry_point = get_quick_entry_point_from_compiled_code(method);
+  uintptr_t method_header = 0UL;
+  if (((!is_quick_generic_jni_stub(
+           existing_entry_point, runtime_obj, thread_obj)) &&
+       (!is_quick_resolution_stub(
+           existing_entry_point, runtime_obj, thread_obj)) &&
+       (!is_quick_to_interpreter_bridge(
+           existing_entry_point, runtime_obj, thread_obj)))) {
+    auto entry_point_tmp = existing_entry_point;
+    method_header = get_oat_method_header_from_entry_point(entry_point_tmp);
+    bool ret = method_header_contains(method_header, pc);
+    if (ret) {
+      return (unsigned long)method_header;
+    }
+  }
+  auto oat_method = find_oat_method_for(method, runtime_obj);
+  if ((!oat_method.success_b)) {
+    if (is_quick_resolution_stub(
+            existing_entry_point, runtime_obj, thread_obj)) {
+      return 0UL;
+    }
+  }
+  auto oat_entry_point = get_quick_code(oat_method);
+  if (((oat_entry_point == 0UL) ||
+       is_quick_generic_jni_stub(oat_entry_point, runtime_obj, thread_obj))) {
+    return 0UL;
+  }
+  oat_entry_point = oat_entry_point;
+  method_header = get_oat_method_header_from_entry_point(oat_entry_point);
+  if ((pc == 0UL)) {
+    return (unsigned long)method_header;
+  }
+  return (unsigned long)method_header;
+}
+
+auto is_abstract_method(uintptr_t method) {
+  uintptr_t kAccAbstract = 1024UL;
+  return (get_method_access_flags(method) & kAccAbstract);
+}
+
+uintptr_t read_variant_size(uintptr_t code_info_ptr) {
+  uintptr_t tmp = code_info_ptr & 0x0F;
+  uint32_t kVarintSmallValue = 11;
+  uint32_t kali = 11;
+  size_t kStackAlignment = 16;
+  if (tmp > kVarintSmallValue) {
+    return (code_info_ptr >> 4 & 0x0F) * kStackAlignment;
+  } else {
+    return tmp * kStackAlignment;
+  }
+}
+
+auto get_frame_size(
+    uintptr_t frameptr,
+    uintptr_t runtime_obj,
+    uintptr_t thread_obj,
+    uintptr_t pc) {
+  uintptr_t method = frameptr;
+  auto entry_point = get_quick_entry_point_from_compiled_code(method);
+  auto oat_quick_method_header =
+      get_oat_quick_method_header(method, runtime_obj, thread_obj, pc);
+  if ((oat_quick_method_header != 0UL)) {
+    uint32_t vmap_table_offset =
+        Read4(AccessField(oat_quick_method_header, 0UL));
+    uintptr_t code_info_ptr = Read4(AccessFieldDesc(
+        AccessField(oat_quick_method_header, 8UL), vmap_table_offset));
+    uintptr_t frame_size = read_variant_size(code_info_ptr);
+    return (unsigned int)frame_size;
+  }
+  uint32_t size = 0U;
+  uintptr_t callee_save_methods = AccessField(runtime_obj, 0UL);
+  uintptr_t kSaveAll = 0UL;
+  uintptr_t kRefsOnly = 1UL;
+  uintptr_t kRefsAndArgs = 2UL;
+  uintptr_t method_info = 0UL;
+  if (is_abstract_method(method)) {
+    return 224U;
+  }
+  if (is_runtime_method(method)) {
+    if ((frameptr ==
+         Read8(AccessArrayItem(callee_save_methods, kRefsAndArgs, 8UL)))) {
+      return 224U;
+    } else {
+      if ((frameptr ==
+           Read8(AccessArrayItem(callee_save_methods, kSaveAll, 8UL)))) {
+        return 176U;
+      } else {
+        return 96U;
+      }
+    }
+    size = Read4(AccessField(method_info, 0UL));
+    return size;
+  }
+  if (is_proxy_method(method)) {
+    if (is_direct_method(method)) {
+      auto info = get_quick_frame_info_from_entry_point(entry_point);
+      size = Read4(AccessField(info, 0UL));
+      return size;
+    } else {
+      return 224U;
+    }
+  }
+  uintptr_t code = 0UL;
+  bool is_native = false;
+  if ((is_quick_resolution_stub(entry_point, runtime_obj, thread_obj) ||
+       is_quick_to_interpreter_bridge(entry_point, runtime_obj, thread_obj))) {
+    if (is_native_method(method)) {
+      is_native = true;
+    } else {
+    }
+  }
+  code = entry_point;
+  if ((is_native || is_quick_generic_jni_stub(code, runtime_obj, thread_obj))) {
+    uint32_t callee_info_size = 224U;
+    uintptr_t voidptr_size = 8UL;
+    uintptr_t artmethodptr_size = 8UL;
+    auto num_refs = (get_number_of_refs_without_receiver(method) + 1UL);
+    uintptr_t handle_scope_size = (12U + (4UL * num_refs));
+    size =
+        (((callee_info_size - voidptr_size) + artmethodptr_size) +
+         handle_scope_size);
+    uintptr_t kStackAlignment = 16UL;
+    size = round_up(size, kStackAlignment);
+    return size;
+  }
+  auto frame_info = get_quick_frame_info_from_entry_point(code);
+  size = Read4(AccessField(frame_info, 0UL));
+  return size;
+}
+
+auto unwind(unwind_callback_t __unwind_callback, void* __unwind_data) {
+  uintptr_t thread = get_art_thread();
+  if ((thread == 0UL)) {
+    return true;
+  }
+  auto runtime = get_runtime_from_thread(thread);
+  uintptr_t thread_obj = thread;
+  auto runtime_obj = runtime;
+  uintptr_t tls = AccessField(thread_obj, 152UL);
+  uintptr_t mstack = AccessField(tls, 24UL);
+  while ((mstack != 0UL)) {
+    uint64_t quick_frame =
+        (Read8(AccessField(AccessField(mstack, 0UL), 0UL)) & (~1UL));
+    quick_frame = quick_frame;
+    uint64_t shadow_frame = Read8(AccessField(mstack, 16UL));
+    shadow_frame = shadow_frame;
+    uintptr_t pc = 0UL;
+    uintptr_t kMaxFrames = 1024UL;
+    uintptr_t depth = 0UL;
+    if ((quick_frame != 0UL)) {
+      while (((quick_frame != 0UL) && (depth < kMaxFrames))) {
+        uint64_t frameptr = Read8(quick_frame);
+        if ((frameptr == 0UL)) {
+          break;
+        }
+        uint64_t frame = frameptr;
+        if ((!is_runtime_method(frame))) {
+          if ((!__unwind_callback(frame, __unwind_data))) {
+            return false;
+          }
+        }
+        auto size = get_frame_size(frameptr, runtime_obj, thread_obj, pc);
+        auto return_pc_offset = (size - 8UL);
+        uint64_t return_pc_addr = (quick_frame + return_pc_offset);
+        uint64_t return_pc = return_pc_addr;
+        pc = Read8(return_pc);
+        quick_frame = (quick_frame + size);
+        depth = (depth + 1UL);
+      }
+    } else {
+      if ((shadow_frame != 0UL)) {
+        while (((shadow_frame != 0UL) && (depth < kMaxFrames))) {
+          uint64_t frame_obj = shadow_frame;
+          uint64_t artmethodptr = Read8(AccessField(frame_obj, 8UL));
+          uint64_t artmethod = artmethodptr;
+          if ((!is_runtime_method(artmethod))) {
+            if ((!__unwind_callback(artmethod, __unwind_data))) {
+              return false;
+            }
+          }
+          shadow_frame = Read8(AccessField(frame_obj, 0UL));
+          depth = (depth + 1UL);
+        }
+      }
+    }
+    uint64_t link = Read8(AccessField(mstack, 8UL));
+    if ((link == 0UL)) {
+      break;
+    }
+    mstack = link;
+  }
+  return true;
+}

--- a/cpp/profiler/unwindc/android_1000/x86/unwinder.h
+++ b/cpp/profiler/unwindc/android_1000/x86/unwinder.h
@@ -1,0 +1,744 @@
+// @nolint
+// @generated
+struct OatMethod {
+  uintptr_t begin_uintptr;
+  uintptr_t offset_uintptr;
+  bool success_b;
+};
+struct OatClass {
+  uintptr_t oat_file_uintptr;
+  intptr_t status_intptr;
+  uintptr_t type_uintptr;
+  uintptr_t bitmap_size_uintptr;
+  uintptr_t bitmap_ptr_uintptr;
+  uintptr_t methods_ptr_uintptr;
+  bool success_b;
+};
+struct ArraySlice {
+  uintptr_t array_uintptr;
+  uintptr_t size_uintptr;
+  uintptr_t element_size_uintptr;
+};
+auto get_runtime_from_thread(uintptr_t thread) {
+  uint32_t jni_env = Read4(AccessField(AccessField(thread, 136U), 28U));
+  uint32_t java_vm = Read4(AccessField(jni_env, 8U));
+  uint32_t runtime = Read4(AccessField(java_vm, 4U));
+  return runtime;
+}
+
+auto get_runtime() {
+  return get_runtime_from_thread(get_art_thread());
+}
+
+auto get_class_dexfile(uintptr_t cls) {
+  uintptr_t dexcache_heap_ref = AccessField(cls, 16U);
+  uintptr_t dexcache_ptr = AccessField(dexcache_heap_ref, 0U);
+  dexcache_ptr = Read4(AccessField(dexcache_ptr, 0U));
+  uintptr_t dexcache = dexcache_ptr;
+  uint64_t dexfile = Read8(AccessField(dexcache, 16U));
+  return dexfile;
+}
+
+auto get_dexfile_string_by_idx(uintptr_t dexfile, uintptr_t idx) {
+  idx = idx;
+  uintptr_t id = AccessArrayItem(Read4(AccessField(dexfile, 40U)), idx, 4U);
+  uint32_t begin = Read4(AccessField(dexfile, 12U));
+  uint32_t string_data_off = Read4(AccessField(id, 0U));
+  uintptr_t ptr = AdvancePointer(begin, (string_data_off * 1U));
+  uintptr_t val = ptr;
+  uintptr_t length = 0U;
+  uintptr_t index = 0U;
+  bool proceed = true;
+  while (proceed) {
+    uint8_t byte = Read1(AccessArrayItem(val, index, 1U));
+    length = (length | ((byte & 127U) << (index * 7U)));
+    proceed = ((byte & 128U) != 0U);
+    index = (index + 1U);
+  }
+  string_t result =
+      String(AdvancePointer(ptr, (index * 1U)), "ascii", "ignore", length);
+  return String(result);
+}
+
+auto get_declaring_class(uintptr_t method) {
+  uintptr_t declaring_class_gc_root = AccessField(method, 0U);
+  uintptr_t declaring_class_ref = AccessField(declaring_class_gc_root, 0U);
+  uint32_t declaring_class_ptr = Read4(AccessField(declaring_class_ref, 0U));
+  uint32_t declaring_class = declaring_class_ptr;
+  return declaring_class;
+}
+
+auto get_method_trace_id(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uintptr_t signature = AccessField(Read4(AccessField(dexfile, 36U)), 12U);
+  uint32_t dex_id = Read4(signature);
+  dex_id = dex_id;
+  uint32_t method_id = Read4(AccessField(method, 12U));
+  return GetMethodTraceId(dex_id, method_id);
+}
+
+auto get_method_name(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t dex_method_index = Read4(AccessField(method, 12U));
+  uintptr_t method_id =
+      AccessArrayItem(Read4(AccessField(dexfile, 52U)), dex_method_index, 8U);
+  uintptr_t name_idx = AccessField(method_id, 4U);
+  name_idx = Read4(AccessField(name_idx, 0U));
+  return get_dexfile_string_by_idx(dexfile, name_idx);
+}
+
+auto get_class_descriptor(uintptr_t cls) {
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t typeidx = Read4(AccessField(cls, 84U));
+  uintptr_t typeid_ =
+      AccessArrayItem(Read4(AccessField(dexfile, 44U)), typeidx, 4U);
+  uintptr_t descriptor_idx = AccessField(typeid_, 0U);
+  descriptor_idx = Read4(AccessField(descriptor_idx, 0U));
+  return get_dexfile_string_by_idx(dexfile, descriptor_idx);
+}
+
+auto get_method_shorty(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t dex_method_index = Read4(AccessField(method, 12U));
+  uintptr_t method_id =
+      AccessArrayItem(Read4(AccessField(dexfile, 52U)), dex_method_index, 8U);
+  uint16_t proto_idx = Read2(AccessField(method_id, 2U));
+  uintptr_t method_proto_id =
+      AccessArrayItem(Read4(AccessField(dexfile, 56U)), proto_idx, 12U);
+  uintptr_t shorty_id = AccessField(method_proto_id, 0U);
+  shorty_id = Read4(AccessField(shorty_id, 0U));
+  return get_dexfile_string_by_idx(dexfile, shorty_id);
+}
+
+auto get_number_of_refs_without_receiver(uintptr_t method) {
+  auto shorty = get_method_shorty(method);
+  return CountShortyRefs(shorty);
+}
+
+auto get_method_access_flags(uintptr_t method) {
+  uintptr_t access_flags = AccessField(method, 4U);
+  access_flags = Read4(AccessField(access_flags, 0U));
+  return access_flags;
+}
+
+auto is_runtime_method(uintptr_t method) {
+  uint32_t dex_method_index = Read4(AccessField(method, 12U));
+  bool is_runtime_method = (dex_method_index == 4294967295U);
+  return is_runtime_method;
+}
+
+auto is_proxy_method(uintptr_t method) {
+  auto declaring_class = get_declaring_class(method);
+  uint32_t class_access_flags = Read4(AccessField(declaring_class, 64U));
+  uintptr_t kAccClassIsProxy = 262144U;
+  if ((class_access_flags & kAccClassIsProxy)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_static_method(uintptr_t method) {
+  uintptr_t kAccStatic = 8U;
+  if ((get_method_access_flags(method) & kAccStatic)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_direct_method(uintptr_t method) {
+  uintptr_t kAccStatic = 8U;
+  uintptr_t kAccPrivate = 2U;
+  uintptr_t kAccConstructor = 65536U;
+  if ((get_method_access_flags(method) &
+       ((kAccStatic | kAccPrivate) | kAccConstructor))) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_native_method(uintptr_t method) {
+  uintptr_t kAccNative = 256U;
+  if ((get_method_access_flags(method) & kAccNative)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+auto is_quick_resolution_stub(
+    uintptr_t entry_point,
+    uintptr_t runtime,
+    uintptr_t thread) {
+  uint32_t class_linker = Read4(AccessField(runtime, 336U));
+  uintptr_t entry_points = AccessField(AccessField(thread, 136U), 156U);
+  return (
+      (Read4(AccessField(class_linker, 168U)) == entry_point) ||
+      (Read4(AccessField(entry_points, 380U)) == entry_point));
+}
+
+auto is_quick_to_interpreter_bridge(
+    uintptr_t entry_point,
+    uintptr_t runtime,
+    uintptr_t thread) {
+  uint32_t class_linker = Read4(AccessField(runtime, 336U));
+  uintptr_t entry_points = AccessField(AccessField(thread, 136U), 156U);
+  return (
+      (Read4(AccessField(class_linker, 180U)) == entry_point) ||
+      (Read4(AccessField(entry_points, 384U)) == entry_point));
+}
+
+auto is_quick_generic_jni_stub(
+    uintptr_t entry_point,
+    uintptr_t runtime,
+    uintptr_t thread) {
+  uint32_t class_linker = Read4(AccessField(runtime, 336U));
+  uintptr_t entry_points = AccessField(AccessField(thread, 136U), 156U);
+  return (
+      (Read4(AccessField(class_linker, 176U)) == entry_point) ||
+      (Read4(AccessField(entry_points, 204U)) == entry_point));
+}
+
+auto get_quick_entry_point_from_compiled_code(uintptr_t method) {
+  uintptr_t ptr_fields = AccessField(method, 20U);
+  uint32_t entry_point = Read4(AccessField(ptr_fields, 4U));
+  entry_point = entry_point;
+  return entry_point;
+}
+
+auto get_oat_method_header_from_entry_point(uintptr_t entry_point) {
+  entry_point = entry_point;
+  entry_point = (entry_point & (~1U));
+  uintptr_t header_offset = 24U;
+  uintptr_t oat_method_header = (entry_point - header_offset);
+  return oat_method_header;
+}
+
+auto get_quick_frame_info_from_entry_point(uintptr_t entry_point) {
+  auto oat_method_header = get_oat_method_header_from_entry_point(entry_point);
+  return AccessField(oat_method_header, 8U);
+}
+
+auto method_header_contains(uintptr_t method_header, uintptr_t pc) {
+  uintptr_t code = AccessField(method_header, 24U);
+  uint32_t code_size = Read4(AccessField(method_header, 20U));
+  uintptr_t kCodeSizeMask = (~2147483648U);
+  code_size = (code_size & kCodeSizeMask);
+  return ((code <= pc) && (pc <= (code + code_size)));
+}
+
+auto is_resolved(uintptr_t cls) {
+  uint32_t status = Read4(AccessField(cls, 112U));
+  status = (status >> (32U - 4U));
+  uintptr_t kStatusResolved = 7U;
+  uintptr_t kStatusErrorResolved = 2U;
+  return ((status >= 4U) || (status == kStatusErrorResolved));
+}
+
+auto get_oat_class(uintptr_t oat_dex_file, uintptr_t class_def_idx) {
+  uint32_t oat_class_offsets_pointer = Read4(AccessField(oat_dex_file, 52U));
+  uintptr_t oat_class_offset =
+      AdvancePointer(oat_class_offsets_pointer, (class_def_idx * 4U));
+  oat_class_offset = Read4(oat_class_offset);
+  uint32_t oat_file = Read4(AccessField(oat_dex_file, 0U));
+  uint32_t oat_file_begin = Read4(AccessField(oat_file, 20U));
+  uintptr_t oat_class_pointer =
+      AdvancePointer(oat_file_begin, (oat_class_offset * 1U));
+
+  uintptr_t status_pointer = oat_class_pointer;
+  uint16_t status = Read2(status_pointer);
+  uintptr_t kStatusMax = 15U;
+
+  uintptr_t type_pointer = AdvancePointer(status_pointer, (2U * 1U));
+
+  uint16_t oat_type = Read2(type_pointer);
+  uintptr_t kOatClassMax = 3U;
+
+  uintptr_t after_type_pointer = AdvancePointer(type_pointer, (2U * 1U));
+
+  uintptr_t bitmap_size = 0U;
+  uintptr_t bitmap_pointer = 0U;
+  uintptr_t methods_pointer = 0U;
+  uintptr_t kOatClassNoneCompiled = 2U;
+  if ((oat_type != kOatClassNoneCompiled)) {
+    uintptr_t kOatClassSomeCompiled = 1U;
+    if ((oat_type == kOatClassSomeCompiled)) {
+      bitmap_size = Read4(after_type_pointer);
+      bitmap_pointer = AdvancePointer(after_type_pointer, (4U * 1U));
+
+      methods_pointer = AdvancePointer(bitmap_pointer, (bitmap_size * 1U));
+    } else {
+      methods_pointer = after_type_pointer;
+    }
+  }
+  return OatClass{
+      .oat_file_uintptr = oat_file,
+      .status_intptr = status,
+      .type_uintptr = oat_type,
+      .bitmap_size_uintptr = bitmap_size,
+      .bitmap_ptr_uintptr = bitmap_pointer,
+      .methods_ptr_uintptr = methods_pointer,
+      .success_b = true,
+  };
+}
+
+auto find_oat_class(uintptr_t cls) {
+  auto dex_file = get_class_dexfile(cls);
+  uint32_t class_def_idx = Read4(AccessField(cls, 80U));
+  uintptr_t kDexNoIndex16 = 65535U;
+
+  uint32_t oat_dex_file = Read4(AccessField(dex_file, 80U));
+  if (((oat_dex_file == 0U) || (Read4(AccessField(oat_dex_file, 0U)) == 0U))) {
+    return OatClass{
+        .oat_file_uintptr = 0,
+        .status_intptr = -1,
+        .type_uintptr = 2,
+        .bitmap_size_uintptr = 0,
+        .bitmap_ptr_uintptr = 0,
+        .methods_ptr_uintptr = 0,
+        .success_b = false,
+    };
+  } else {
+    return get_oat_class(oat_dex_file, class_def_idx);
+  }
+}
+
+auto count_bits_in_word(uintptr_t word) {
+  uintptr_t count = 0U;
+  while ((word > 0U)) {
+    if ((word & 1U)) {
+      count = (count + 1U);
+    }
+    word = (word >> 1U);
+  }
+  return count;
+}
+
+auto get_oat_method_offsets(
+    struct OatClass const& struct_OatClass,
+    uintptr_t method_index) {
+  uintptr_t methods_ptr = struct_OatClass.methods_ptr_uintptr;
+  uintptr_t oc_type = struct_OatClass.type_uintptr;
+  uintptr_t bitmap_ptr = struct_OatClass.bitmap_ptr_uintptr;
+  if ((methods_ptr == 0U)) {
+    uintptr_t kOatClassNoneCompiled = 2U;
+
+    return methods_ptr;
+  }
+  uintptr_t methods_pointer_index = 0U;
+  if ((bitmap_ptr == 0U)) {
+    uintptr_t kOatClassAllCompiled = 0U;
+
+    methods_pointer_index = method_index;
+  } else {
+    uintptr_t kOatClassSomeCompiled = 1U;
+
+    uintptr_t word_index = (method_index >> 5U);
+    uintptr_t bit_mask = (1U << (method_index & 31U));
+    uintptr_t is_bit_set = AdvancePointer(bitmap_ptr, (word_index * 4U));
+    is_bit_set = Read4(is_bit_set);
+    is_bit_set = ((is_bit_set & bit_mask) != 0U);
+    if ((!is_bit_set)) {
+      return is_bit_set;
+    }
+    uintptr_t word_end = (method_index >> 5U);
+    uintptr_t partial_word_bits = (method_index & 31U);
+    uintptr_t count = 0U;
+    uintptr_t word = 0U;
+    uintptr_t elem = 0U;
+    while ((word < word_end)) {
+      elem = AdvancePointer(bitmap_ptr, (word * 4U));
+      elem = Read4(elem);
+      count = (count + count_bits_in_word(elem));
+      word = (word + 1U);
+    }
+    if ((partial_word_bits != 0U)) {
+      elem = AdvancePointer(bitmap_ptr, (word_end * 4U));
+      elem = Read4(elem);
+      uint32_t shifted = 4294967295U;
+      count =
+          (count +
+           count_bits_in_word((elem & (~(shifted << partial_word_bits)))));
+    }
+    methods_pointer_index = count;
+  }
+  uintptr_t ret = AdvancePointer(methods_ptr, (methods_pointer_index * 4U));
+  return ret;
+}
+
+auto runtime_is_aot_compiler(uintptr_t runtime, uintptr_t instance) {
+  uint32_t jit =
+      Read4(AccessField(AccessField(AccessField(runtime, 364U), 0U), 0U));
+  bool use_jit_compilation = ((jit != 0U) && Read1(AccessField(jit, 252U)));
+  uint32_t compiler_callbacks = Read4(AccessField(runtime, 148U));
+  return ((!use_jit_compilation) && (compiler_callbacks != 0U));
+}
+
+auto get_oat_method(
+    uintptr_t runtime_obj,
+    struct OatClass const& struct_OatClass,
+    uintptr_t oat_method_index) {
+  auto oat_method_offsets =
+      get_oat_method_offsets(struct_OatClass, oat_method_index);
+  if ((oat_method_offsets == 0U)) {
+    return OatMethod{
+        .begin_uintptr = 0,
+        .offset_uintptr = 0,
+        .success_b = true,
+    };
+  }
+  uintptr_t runtime_current = get_runtime();
+  uintptr_t begin_uintptr = 0U;
+  uintptr_t oat_file = struct_OatClass.oat_file_uintptr;
+  if ((Read1(AccessField(oat_file, 44U)) ||
+       ((runtime_current == 0U) ||
+        runtime_is_aot_compiler(runtime_current, runtime_current)))) {
+    begin_uintptr = Read4(AccessField(oat_file, 20U));
+    uint32_t offset_uintptr = Read4(AccessField(oat_method_offsets, 0U));
+    return OatMethod{
+        .begin_uintptr = begin_uintptr,
+        .offset_uintptr = offset_uintptr,
+        .success_b = true,
+    };
+  }
+  begin_uintptr = Read4(AccessField(oat_file, 20U));
+  return OatMethod{
+      .begin_uintptr = begin_uintptr,
+      .offset_uintptr = 0,
+      .success_b = true,
+  };
+}
+
+auto round_up(uintptr_t x, uintptr_t n) {
+  uintptr_t arg1 = ((x + n) - 1U);
+  uintptr_t arg2 = n;
+  return (arg1 & (-arg2));
+}
+
+auto length_prefixed_array_at(
+    uintptr_t array,
+    uintptr_t idx,
+    uintptr_t element_size,
+    uintptr_t alignment) {
+  uintptr_t ptr = array;
+
+  uintptr_t data_offset = 4U;
+  auto element_offset = round_up(data_offset, alignment);
+  element_offset = (element_offset + (idx * element_size));
+  uintptr_t ret = (ptr + element_offset);
+  return ret;
+}
+
+auto get_virtual_methods(
+    uintptr_t method,
+    uintptr_t cls,
+    uintptr_t start_offset) {
+  uintptr_t ptr_size = 4U;
+  uintptr_t num_methods = 0U;
+  uint64_t methods_ptr = Read8(AccessField(cls, 48U));
+  if ((methods_ptr == 0U)) {
+    num_methods = 0U;
+  } else {
+    num_methods = Read4(AccessField(methods_ptr, 0U));
+  }
+  uintptr_t end_offset = num_methods;
+
+  uintptr_t size = (end_offset - start_offset);
+  if ((size == 0U)) {
+    return ArraySlice{
+        .array_uintptr = 0,
+        .size_uintptr = 0,
+        .element_size_uintptr = 0,
+    };
+  }
+
+  uintptr_t method_size = 20U;
+  method_size = round_up(method_size, ptr_size);
+  method_size = (method_size + 8U);
+  uintptr_t method_alignment = ptr_size;
+  auto array_method =
+      length_prefixed_array_at(methods_ptr, 0U, method_size, method_alignment);
+  uint32_t size_uintptr = Read4(AccessField(methods_ptr, 0U));
+  auto array_slice = ArraySlice{
+      .array_uintptr = array_method,
+      .size_uintptr = size_uintptr,
+      .element_size_uintptr = method_size,
+  };
+
+  uintptr_t tmp = array_slice.array_uintptr;
+  tmp = (tmp + (start_offset * array_slice.element_size_uintptr));
+  return ArraySlice{
+      .array_uintptr = tmp,
+      .size_uintptr = size,
+      .element_size_uintptr = array_slice.element_size_uintptr,
+  };
+}
+
+auto find_oat_method_for(uintptr_t method, uintptr_t runtime_obj) {
+  uintptr_t oat_method_index = 0U;
+  auto cls = get_declaring_class(method);
+  if ((is_static_method(method) || is_direct_method(method))) {
+    oat_method_index = Read2(AccessField(method, 16U));
+  } else {
+    oat_method_index = Read2(AccessField(cls, 118U));
+    auto virtual_methods = get_virtual_methods(method, cls, oat_method_index);
+    uintptr_t iterator = virtual_methods.array_uintptr;
+    uintptr_t end =
+        (iterator +
+         (virtual_methods.size_uintptr * virtual_methods.element_size_uintptr));
+    bool found_virtual = false;
+    while ((iterator != end)) {
+      uintptr_t art_method = iterator;
+      if ((Read4(AccessField(art_method, 12U)) ==
+           Read4(AccessField(method, 12U)))) {
+        found_virtual = true;
+        break;
+      }
+      oat_method_index = (oat_method_index + 1U);
+      iterator = (iterator + virtual_methods.element_size_uintptr);
+    }
+  }
+  auto oat_class = find_oat_class(cls);
+  if ((!oat_class.success_b)) {
+    return OatMethod{
+        .begin_uintptr = 0,
+        .offset_uintptr = 0,
+        .success_b = false,
+    };
+  }
+  return get_oat_method(runtime_obj, oat_class, oat_method_index);
+}
+
+auto get_oat_pointer(
+    struct OatMethod const& struct_OatMethod,
+    uintptr_t offset) {
+  if ((offset == 0U)) {
+    return offset;
+  }
+  uintptr_t begin = struct_OatMethod.begin_uintptr;
+  return AdvancePointer(begin, (offset * 1U));
+}
+
+auto get_code_offset(struct OatMethod const& struct_OatMethod) {
+  uintptr_t oat_method_offset = struct_OatMethod.offset_uintptr;
+  auto code = get_oat_pointer(struct_OatMethod, oat_method_offset);
+  code = (code & (~1U));
+  if ((code == 0U)) {
+    return 0U;
+  }
+  uintptr_t method_header_size = 24U;
+  code = (code - method_header_size);
+  uintptr_t kCodeSizeMask = (~2147483648U);
+  uint32_t code_size = Read4(AccessField(code, 20U));
+  code_size = (code_size & kCodeSizeMask);
+  if ((code_size == 0U)) {
+    return 0U;
+  }
+  return oat_method_offset;
+}
+
+auto get_quick_code(struct OatMethod const& struct_OatMethod) {
+  auto offset = get_code_offset(struct_OatMethod);
+  auto quick_code = get_oat_pointer(struct_OatMethod, offset);
+  return quick_code;
+}
+
+auto get_oat_quick_method_header(
+    uintptr_t method,
+    uintptr_t runtime_obj,
+    uintptr_t thread_obj,
+    uintptr_t pc) {
+  if (is_runtime_method(method)) {
+    return 0U;
+  }
+  auto existing_entry_point = get_quick_entry_point_from_compiled_code(method);
+
+  uintptr_t method_header = 0U;
+  if (((!is_quick_generic_jni_stub(
+           existing_entry_point, runtime_obj, thread_obj)) &&
+       (!is_quick_resolution_stub(
+           existing_entry_point, runtime_obj, thread_obj)) &&
+       (!is_quick_to_interpreter_bridge(
+           existing_entry_point, runtime_obj, thread_obj)))) {
+    auto entry_point_tmp = existing_entry_point;
+    method_header = get_oat_method_header_from_entry_point(entry_point_tmp);
+    if (method_header_contains(method_header, pc)) {
+      return method_header;
+    }
+  }
+  auto oat_method = find_oat_method_for(method, runtime_obj);
+  if ((!oat_method.success_b)) {
+    if (is_quick_resolution_stub(
+            existing_entry_point, runtime_obj, thread_obj)) {
+      return 0U;
+    }
+  }
+  auto oat_entry_point = get_quick_code(oat_method);
+  if (((oat_entry_point == 0U) ||
+       is_quick_generic_jni_stub(oat_entry_point, runtime_obj, thread_obj))) {
+    return 0U;
+  }
+  oat_entry_point = oat_entry_point;
+  method_header = get_oat_method_header_from_entry_point(oat_entry_point);
+  if ((pc == 0U)) {
+    return method_header;
+  }
+  return method_header;
+}
+
+auto is_abstract_method(uintptr_t method) {
+  uintptr_t kAccAbstract = 1024U;
+  return (get_method_access_flags(method) & kAccAbstract);
+}
+
+auto get_frame_size(
+    uintptr_t frameptr,
+    uintptr_t runtime_obj,
+    uintptr_t thread_obj,
+    uintptr_t pc) {
+  uintptr_t method = frameptr;
+  auto entry_point = get_quick_entry_point_from_compiled_code(method);
+  auto oat_quick_method_header =
+      get_oat_quick_method_header(method, runtime_obj, thread_obj, pc);
+  if ((oat_quick_method_header != 0U)) {
+    return Read4(AccessField(AccessField(oat_quick_method_header, 8U), 0U));
+  }
+  uint32_t size = 0U;
+  uintptr_t callee_save_methods = AccessField(runtime_obj, 0U);
+  uintptr_t callee_save_infos = AccessField(runtime_obj, 76U);
+  uintptr_t kSaveAll = 0U;
+  uintptr_t kRefsOnly = 1U;
+  uintptr_t kRefsAndArgs = 2U;
+  uintptr_t method_info = 0U;
+  if (is_abstract_method(method)) {
+    method_info = AccessArrayItem(callee_save_infos, kRefsAndArgs, 12U);
+    size = Read4(AccessField(method_info, 0U));
+    return size;
+  }
+  if (is_runtime_method(method)) {
+    if ((frameptr ==
+         Read8(AccessArrayItem(callee_save_methods, kRefsAndArgs, 8U)))) {
+      method_info = AccessArrayItem(callee_save_infos, kRefsAndArgs, 12U);
+    } else {
+      if ((frameptr ==
+           Read8(AccessArrayItem(callee_save_methods, kSaveAll, 8U)))) {
+        method_info = AccessArrayItem(callee_save_infos, kSaveAll, 12U);
+      } else {
+        method_info = AccessArrayItem(callee_save_infos, kRefsOnly, 12U);
+      }
+    }
+    size = Read4(AccessField(method_info, 0U));
+    return size;
+  }
+  if (is_proxy_method(method)) {
+    if (is_direct_method(method)) {
+      auto info = get_quick_frame_info_from_entry_point(entry_point);
+      size = Read4(AccessField(info, 0U));
+      return size;
+    } else {
+      method_info = AccessArrayItem(callee_save_infos, kRefsAndArgs, 12U);
+      size = Read4(AccessField(method_info, 0U));
+      return size;
+    }
+  }
+  uintptr_t code = 0U;
+  bool is_native = false;
+  if ((is_quick_resolution_stub(entry_point, runtime_obj, thread_obj) ||
+       is_quick_to_interpreter_bridge(entry_point, runtime_obj, thread_obj))) {
+    if (is_native_method(method)) {
+      is_native = true;
+    } else {
+      ;
+    }
+  }
+  code = entry_point;
+  if ((is_native || is_quick_generic_jni_stub(code, runtime_obj, thread_obj))) {
+    uintptr_t callee_info =
+        AccessArrayItem(callee_save_infos, kRefsAndArgs, 12U);
+    uint32_t callee_info_size = Read4(AccessField(callee_info, 0U));
+    uintptr_t voidptr_size = 4U;
+    uintptr_t artmethodptr_size = 4U;
+    auto num_refs = (get_number_of_refs_without_receiver(method) + 1U);
+    uintptr_t handle_scope_size = (8U + (4U * num_refs));
+    size =
+        (((callee_info_size - voidptr_size) + artmethodptr_size) +
+         handle_scope_size);
+    uintptr_t kStackAlignment = 16U;
+    size = round_up(size, kStackAlignment);
+    return size;
+  }
+  auto frame_info = get_quick_frame_info_from_entry_point(code);
+  size = Read4(AccessField(frame_info, 0U));
+  return size;
+}
+
+auto unwind(unwind_callback_t __unwind_callback, void* __unwind_data) {
+  uintptr_t thread = get_art_thread();
+  if ((thread == 0U)) {
+    return true;
+  }
+  auto runtime = get_runtime_from_thread(thread);
+  uintptr_t thread_obj = thread;
+  auto runtime_obj = runtime;
+  uintptr_t tls = AccessField(thread_obj, 136U);
+  uintptr_t mstack = AccessField(tls, 12U);
+  uint32_t generic_jni_trampoline =
+      Read4(AccessField(AccessField(tls, 156U), 204U));
+  while ((mstack != 0U)) {
+    uint32_t quick_frame =
+        (Read4(AccessField(AccessField(mstack, 0U), 0U)) & (~1U));
+    quick_frame = quick_frame;
+    uint32_t shadow_frame = Read4(AccessField(mstack, 8U));
+    shadow_frame = shadow_frame;
+    uintptr_t pc = 0U;
+    uintptr_t kMaxFrames = 1024U;
+    uintptr_t depth = 0U;
+    if ((quick_frame != 0U)) {
+      while (((quick_frame != 0U) && (depth < kMaxFrames))) {
+        uint32_t frameptr = Read4(quick_frame);
+        if ((frameptr == 0U)) {
+          break;
+        }
+        uint32_t frame = frameptr;
+        if ((!is_runtime_method(frame))) {
+          if ((!__unwind_callback(frame, __unwind_data))) {
+            return false;
+          }
+        }
+        auto size = get_frame_size(frameptr, runtime_obj, thread_obj, pc);
+        auto return_pc_offset = (size - 4U);
+        uint32_t return_pc_addr = (quick_frame + return_pc_offset);
+        uint32_t return_pc = return_pc_addr;
+        pc = Read4(return_pc);
+        quick_frame = (quick_frame + size);
+        depth = (depth + 1U);
+      }
+    } else {
+      if ((shadow_frame != 0U)) {
+        while (((shadow_frame != 0U) && (depth < kMaxFrames))) {
+          uint32_t frame_obj = shadow_frame;
+          uint32_t artmethodptr = Read4(AccessField(frame_obj, 4U));
+          uint32_t artmethod = artmethodptr;
+          if ((!is_runtime_method(artmethod))) {
+            if ((!__unwind_callback(artmethod, __unwind_data))) {
+              return false;
+            }
+          }
+          shadow_frame = Read4(AccessField(frame_obj, 0U));
+          depth = (depth + 1U);
+        }
+      }
+    }
+    uint32_t link = Read4(AccessField(mstack, 4U));
+    if ((link == 0U)) {
+      break;
+    }
+    mstack = link;
+  }
+  return true;
+}

--- a/cpp/profiler/unwindc/android_1000/x86_64/unwinder.h
+++ b/cpp/profiler/unwindc/android_1000/x86_64/unwinder.h
@@ -1,0 +1,70 @@
+// @nolint
+
+auto get_class_dexfile(uintptr_t cls) {
+  uintptr_t dexcache_heap_ref = AccessField(cls, 16U);
+  uint32_t dexcache_ptr = Read4(AccessField(dexcache_heap_ref, 0U));
+  uint32_t dexcache = dexcache_ptr;
+  uint64_t dexfile = Read8(AccessField(dexcache, 32U));
+  return dexfile;
+}
+
+auto get_dexfile_string_by_idx(uintptr_t dexfile, uintptr_t idx) {
+  idx = idx;
+  uintptr_t id = AccessArrayItem(Read4(AccessField(dexfile, 36U)), idx, 4U);
+  uint32_t begin = Read4(AccessField(dexfile, 4U));
+  uint32_t string_data_off = Read4(AccessField(id, 0U));
+  uintptr_t ptr = AdvancePointer(begin, (string_data_off * 1U));
+  uintptr_t val = ptr;
+  uintptr_t length = 0U;
+  uintptr_t index = 0U;
+  bool proceed = true;
+  while (proceed) {
+    uint8_t byte = Read1(AccessArrayItem(val, index, 1U));
+    length = (length | ((byte & 127U) << (index * 7U)));
+    proceed = ((byte & 128U) != 0U);
+    index = (index + 1U);
+  }
+  string_t result =
+      String(AdvancePointer(ptr, (index * 1U)), "ascii", "ignore", length);
+  return String(result);
+}
+
+auto get_declaring_class(uintptr_t method) {
+  uintptr_t declaring_class_ref = AccessField(method, 8U);
+  uint32_t declaring_class_ptr = Read4(AccessField(declaring_class_ref, 0U));
+  uint32_t declaring_class = declaring_class_ptr;
+  return declaring_class;
+}
+
+auto get_method_trace_id(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uintptr_t signature = AccessField(Read4(AccessField(dexfile, 32U)), 12U);
+  uint32_t dex_id = Read4(signature);
+  dex_id = dex_id;
+  uint32_t method_id = Read4(AccessField(method, 64U));
+  return GetMethodTraceId(dex_id, method_id);
+}
+
+auto get_method_name(uintptr_t method) {
+  auto cls = get_declaring_class(method);
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t dex_method_index = Read4(AccessField(method, 64U));
+  uintptr_t method_id =
+      AccessArrayItem(Read4(AccessField(dexfile, 48U)), dex_method_index, 8U);
+  uint32_t name_idx = Read4(AccessField(method_id, 4U));
+  return get_dexfile_string_by_idx(dexfile, name_idx);
+}
+
+auto get_class_descriptor(uintptr_t cls) {
+  auto dexfile = get_class_dexfile(cls);
+  uint32_t typeidx = Read4(AccessField(cls, 76U));
+  uintptr_t typeid_ =
+      AccessArrayItem(Read4(AccessField(dexfile, 40U)), typeidx, 4U);
+  uint32_t descriptor_idx = Read4(AccessField(typeid_, 0U));
+  return get_dexfile_string_by_idx(dexfile, descriptor_idx);
+}
+
+auto unwind(unwind_callback_t __unwind_callback, void* __unwind_data) {
+  return false;
+}

--- a/cpp/profiler/unwindc/runtime.h
+++ b/cpp/profiler/unwindc/runtime.h
@@ -181,6 +181,12 @@ __attribute__((always_inline)) inline uintptr_t AccessField(
   return addr + offset;
 }
 
+__attribute__((always_inline)) inline uintptr_t AccessFieldDesc(
+        uintptr_t addr,
+        uint32_t offset) {
+    return addr - offset;
+}
+
 __attribute__((always_inline)) inline uintptr_t
 AccessArrayItem(uintptr_t addr, uint32_t item_size, uint32_t item) {
   return addr + (item_size * item);

--- a/java/main/com/facebook/profilo/provider/stacktrace/ArtCompatibility.java
+++ b/java/main/com/facebook/profilo/provider/stacktrace/ArtCompatibility.java
@@ -59,6 +59,10 @@ public class ArtCompatibility {
         result = readCompatFile(file);
       } else {
         switch (Build.VERSION.RELEASE) {
+          case "10":
+          case "10.0":
+            result = nativeCheck(CPUProfiler.TRACER_ART_UNWINDC_10_0_0);
+            break;
           case "9":
           case "9.0":
           case "9.0.0":

--- a/java/main/com/facebook/profilo/provider/stacktrace/CPUProfiler.java
+++ b/java/main/com/facebook/profilo/provider/stacktrace/CPUProfiler.java
@@ -46,6 +46,7 @@ public class CPUProfiler {
   public static final int TRACER_ART_UNWINDC_8_0_0 = 1 << 12;
   public static final int TRACER_ART_UNWINDC_8_1_0 = 1 << 13;
   public static final int TRACER_ART_UNWINDC_9_0_0 = 1 << 14;
+  public static final int TRACER_ART_UNWINDC_10_0_0 = 1 << 15;
 
   private static int calculateTracers(Context context) {
     int tracers = 0;
@@ -54,6 +55,10 @@ public class CPUProfiler {
       tracers |= TRACER_DALVIK;
     } else if (ArtCompatibility.isCompatible(context)) {
       switch (Build.VERSION.RELEASE) {
+        case "10":
+        case "10.0":
+          tracers |= TRACER_ART_UNWINDC_10_0_0;
+          break;
         case "9":
         case "9.0":
         case "9.0.0":

--- a/java/main/com/facebook/profilo/provider/stacktrace/StackFrameThread.java
+++ b/java/main/com/facebook/profilo/provider/stacktrace/StackFrameThread.java
@@ -76,7 +76,8 @@ public final class StackFrameThread extends BaseTraceProvider {
               | CPUProfiler.TRACER_ART_UNWINDC_5_1
               | CPUProfiler.TRACER_ART_UNWINDC_8_0_0
               | CPUProfiler.TRACER_ART_UNWINDC_8_1_0
-              | CPUProfiler.TRACER_ART_UNWINDC_9_0_0;
+              | CPUProfiler.TRACER_ART_UNWINDC_9_0_0
+              | CPUProfiler.TRACER_ART_UNWINDC_10_0_0;
     }
     if ((providers & PROVIDER_NATIVE_STACK_TRACE) != 0) {
       tracers |= CPUProfiler.TRACER_NATIVE;


### PR DESCRIPTION
@Fortisque @BurntBrunch 
I'm working on java stack-unwind before. Considering the online Android 10.0 user experience, I'm equipped with an arm-based and arm64 version of unwind.h and tested it on the local phone(pixel 3xl and pixel 4a). I hope you can try it and give some advice. **Remind that** the x86/x86-64 has not been supported yet because of scenes to be used and speed., so I left the empty implementation.

By the way, I want to know that the reason why the unwind process crashed (sigbus or sigsegv) randomly.
I tested the sample.apk on my phone(sony on 9.0) and found that almost 20 times of crash out of 1000's unwind  when I use the stacktracethread to get the java stack which goes on with the Android 10.0...