### PR TITLE
Run build and test in circleci instead of travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ jobs:
     steps:
       - checkout
       - *restore-cache
-      
       - attach_workspace:
           at: website
 
@@ -73,8 +72,39 @@ jobs:
           name: Deploy Website
           command: |
             echo "Deploying website..."
-            cd website 
+            cd website
             GIT_USER=docusaurus-bot USE_SSH= yarn run deploy
+
+    - build-and-test:
+      docker:
+        - image: cimg/base:2020.01
+
+      working_directory: ~/profilo
+
+      steps:
+        - checkout
+        - setup_remote_docker
+
+        run:
+          name: Install dependencies
+          command: |
+            apk add --no-cache \
+              py-pip=9.0.0-r1
+            pip install \
+              docker-compose==1.12.0 \
+              awscli==1.11.76
+        - build:
+          name: Build application Docker image
+          command: |
+            docker build -t profilo -f build/Dockerfile .
+        - test:
+          name: Run tests on Docker
+          command: |
+            docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/test.sh
+            docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/build.sh
+            build/copy_artifacts_to_host.sh
+
+
 
 workflows:
   version: 2
@@ -85,3 +115,6 @@ workflows:
           filters: *filter-only-master
           requires:
             - build-website
+  build_and_test:
+    jobs:
+      - build-and-test


### PR DESCRIPTION
Summary: Basically just takes the docker steps from the travis.yml and puts them in circleci's yml

Differential Revision: D26006732

