### PR TITLE
Run build and test in circleci instead of travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            sudo apt-get install docker-ce docker-ce-cli containerd.io golang
+            sudo apt-get install docker-ce docker-ce-cli containerd.io golang-go
       - run:
           name: Build application Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,4 +126,5 @@ workflows:
             - build-website
   build_and_test:
     jobs:
-      - build-and-test
+      - build-and-test:
+        filters: *filter-only-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
 
   build-and-test:
     docker:
-      - image: circleci/golang:1.8
+      - image: cimg/base:2020.01
 
     working_directory: ~/profilo
 
@@ -89,7 +89,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            sudo apt-get install docker-ce docker-ce-cli containerd.io
+            sudo apt-get install docker-ce docker-ce-cli containerd.io golang
       - run:
           name: Build application Docker image
           command: |
@@ -108,10 +108,10 @@ jobs:
             go get github.com/tcnksm/ghr
             VERSION=$(my-binary --version)
             echo "$VERSION"
+            echo "$CIRCLE_SHA1"
             echo "$GITHUB_TOKEN"
             echo "$CIRCLE_PROJECT_USERNAME"
             echo "$CIRCLE_PROJECT_REPONAME"
-            echo "$CIRCLE_SHA1"
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/*
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,16 +108,9 @@ jobs:
             export GOPATH="$HOME/go"
             PATH="$GOPATH/bin:$PATH"
             go get -u github.com/tcnksm/ghr
-            git config --local user.name "Facebook Community Bot"
-            git config --local user.email "nobody@nobody.com"
-            VERSION=$(echo $CIRCLE_SHA1 | cut -c -7)
-            echo "$VERSION"
-            echo "$CIRCLE_SHA1"
-            echo "$GITHUB_TOKEN"
-            echo "$CIRCLE_PROJECT_USERNAME"
-            echo "$CIRCLE_PROJECT_REPONAME"
+            TAG_NAME="release-$(git rev-parse --short ${CIRCLE_SHA1})"
             set -x;
-            ghr -t "${GITHUB_TOKEN}" -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/
+            ghr -t Egj8XP3dXMaTKj2js7c6QwMwRdIMGd -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete $TAG_NAME out/
             set +x;
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
             echo "$CIRCLE_PROJECT_USERNAME"
             echo "$CIRCLE_PROJECT_REPONAME"
             set -x;
-            ghr -t "${GITHUB_TOKEN}" -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/*
+            ghr -t "${GITHUB_TOKEN}" -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/.*
             set +x;
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,11 +89,17 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            apk add --no-cache \
-              py-pip=9.0.0-r1
-            pip install \
-              docker-compose==1.12.0 \
-              awscli==1.11.76
+            sudo apt-get install docker-ce docker-ce-cli containerd.io
+      - build:
+          name: Build application Docker image
+          command: |
+            docker build -t profilo -f build/Dockerfile .
+      - test:
+          name: Run tests on Docker
+          command: |
+            docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/test.sh
+            docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/build.sh
+            build/copy_artifacts_to_host.sh
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,10 +108,10 @@ jobs:
             go get github.com/tcnksm/ghr
             VERSION=$(my-binary --version)
             echo "$VERSION"
-            echo "$CIRCLE_SHA1"
             echo "$GITHUB_TOKEN"
             echo "$CIRCLE_PROJECT_USERNAME"
             echo "$CIRCLE_PROJECT_REPONAME"
+            echo "$CIRCLE_SHA1"
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/*
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,16 +90,29 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get install docker-ce docker-ce-cli containerd.io
-      - docker-build:
+      - run:
           name: Build application Docker image
           command: |
             docker build -t profilo -f build/Dockerfile .
-      - docker-test:
+      - run:
           name: Run tests on Docker
           command: |
             docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/test.sh
             docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/build.sh
             build/copy_artifacts_to_host.sh
+      - run:
+        name: "Publish Release on GitHub"
+        command: |
+          git config --local user.name "Facebook Community Bot"
+          git config --local user.email "nobody@nobody.com"
+          go get github.com/tcnksm/ghr
+          VERSION=$(my-binary --version)
+          echo "$VERSION"
+          echo "$CIRCLE_SHA1"
+          echo "$GITHUB_TOKEN"
+          echo "$CIRCLE_PROJECT_USERNAME"
+          echo "$CIRCLE_PROJECT_REPONAME"
+          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/*
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,6 @@ jobs:
             sudo apt update --yes
             sudo apt-get install docker-ce docker-ce-cli containerd.io --yes
             sudo apt install golang --yes
-            export GOPATH="$HOME/go"
-            PATH="$GOPATH/bin:$PATH"
-            go get -u github.com/tcnksm/ghr
       - run:
           name: Build application Docker image
           command: |
@@ -108,6 +105,9 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
+            export GOPATH="$HOME/go"
+            PATH="$GOPATH/bin:$PATH"
+            go get -u github.com/tcnksm/ghr
             git config --local user.name "Facebook Community Bot"
             git config --local user.email "nobody@nobody.com"
             VERSION=$(echo $CIRCLE_SHA1 | cut -c -7)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,13 +87,13 @@ jobs:
         version: 19.03.13
 
       - run:
-        name: Install dependencies
-        command: |
-          apk add --no-cache \
-            py-pip=9.0.0-r1
-          pip install \
-            docker-compose==1.12.0 \
-            awscli==1.11.76
+          name: Install dependencies
+          command: |
+            apk add --no-cache \
+              py-pip=9.0.0-r1
+            pip install \
+              docker-compose==1.12.0 \
+              awscli==1.11.76
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,9 @@ jobs:
             echo "$GITHUB_TOKEN"
             echo "$CIRCLE_PROJECT_USERNAME"
             echo "$CIRCLE_PROJECT_REPONAME"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/*
+            set -x;
+            ghr -t "${GITHUB_TOKEN}" -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/*
+            set +x;
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ jobs:
 
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+        version: 19.03.13
 
       - run:
         name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,8 @@ jobs:
             sudo apt update --yes
             sudo apt-get install docker-ce docker-ce-cli containerd.io --yes
             sudo apt install golang --yes
+            export GOPATH="$HOME/go"
+            PATH="$GOPATH/bin:$PATH"
             go get -u github.com/tcnksm/ghr
             ghr --help
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,18 +101,18 @@ jobs:
             docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/build.sh
             build/copy_artifacts_to_host.sh
       - run:
-        name: "Publish Release on GitHub"
-        command: |
-          git config --local user.name "Facebook Community Bot"
-          git config --local user.email "nobody@nobody.com"
-          go get github.com/tcnksm/ghr
-          VERSION=$(my-binary --version)
-          echo "$VERSION"
-          echo "$CIRCLE_SHA1"
-          echo "$GITHUB_TOKEN"
-          echo "$CIRCLE_PROJECT_USERNAME"
-          echo "$CIRCLE_PROJECT_REPONAME"
-          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/*
+          name: "Publish Release on GitHub"
+          command: |
+            git config --local user.name "Facebook Community Bot"
+            git config --local user.email "nobody@nobody.com"
+            go get github.com/tcnksm/ghr
+            VERSION=$(my-binary --version)
+            echo "$VERSION"
+            echo "$CIRCLE_SHA1"
+            echo "$GITHUB_TOKEN"
+            echo "$CIRCLE_PROJECT_USERNAME"
+            echo "$CIRCLE_PROJECT_REPONAME"
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/*
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,9 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            sudo apt update
             sudo apt-get install docker-ce docker-ce-cli containerd.io
-            sudo apt update && apt install golang
+            sudo apt install golang
       - run:
           name: Build application Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,6 @@ jobs:
             export GOPATH="$HOME/go"
             PATH="$GOPATH/bin:$PATH"
             go get -u github.com/tcnksm/ghr
-            ghr --help
       - run:
           name: Build application Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
           command: |
             sudo apt-get install docker-ce docker-ce-cli containerd.io
             wget https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz
-            sudo tar -xvf go1.15.3.linux-amd64.tar.gz
+            sudo tar -xvf go1.15.2.linux-amd64.tar.gz
             sudo mv go /usr/local
             export GOROOT=/usr/local/go
             export PATH=$GOROOT/bin:$PATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,16 +93,6 @@ jobs:
           pip install \
             docker-compose==1.12.0 \
             awscli==1.11.76
-      - build:
-        name: Build application Docker image
-        command: |
-          docker build -t profilo -f build/Dockerfile .
-      - test:
-        name: Run tests on Docker
-        command: |
-          docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/test.sh
-          docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/build.sh
-          build/copy_artifacts_to_host.sh
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,11 +90,11 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get install docker-ce docker-ce-cli containerd.io
-      - run:
+      - docker-build:
           name: Build application Docker image
           command: |
             docker build -t profilo -f build/Dockerfile .
-      - run:
+      - docker-test:
           name: Run tests on Docker
           command: |
             docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,13 +107,13 @@ jobs:
           command: |
             git config --local user.name "Facebook Community Bot"
             git config --local user.email "nobody@nobody.com"
-            go get github.com/tcnksm/ghr
             VERSION=$(my-binary --version)
             echo "$VERSION"
             echo "$CIRCLE_SHA1"
             echo "$GITHUB_TOKEN"
             echo "$CIRCLE_PROJECT_USERNAME"
             echo "$CIRCLE_PROJECT_REPONAME"
+            go get -u github.com/tcnksm/ghr
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/*
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get install docker-ce docker-ce-cli containerd.io
-            sudo apt install golong
+            sudo apt install golang
       - run:
           name: Build application Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
             sudo apt update --yes
             sudo apt-get install docker-ce docker-ce-cli containerd.io --yes
             sudo apt install golang --yes
+            go get -u github.com/tcnksm/ghr
       - run:
           name: Build application Docker image
           command: |
@@ -113,7 +114,6 @@ jobs:
             echo "$GITHUB_TOKEN"
             echo "$CIRCLE_PROJECT_USERNAME"
             echo "$CIRCLE_PROJECT_REPONAME"
-            go get -u github.com/tcnksm/ghr
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/*
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,11 +90,7 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get install docker-ce docker-ce-cli containerd.io
-            wget https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz
-            sudo tar -xvf go1.15.2.linux-amd64.tar.gz
-            sudo mv go /usr/local
-            export GOROOT=/usr/local/go
-            export PATH=$GOROOT/bin:$PATH
+            sudo apt install golong
       - run:
           name: Build application Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,4 +127,4 @@ workflows:
   build_and_test:
     jobs:
       - build-and-test:
-        filters: *filter-only-master
+          filters: *filter-only-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get install docker-ce docker-ce-cli containerd.io
-            sudo apt install golang
+            sudo apt update && apt install golang
       - run:
           name: Build application Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
             go get -u github.com/tcnksm/ghr
             TAG_NAME="release-$(git rev-parse --short ${CIRCLE_SHA1})"
             set -x;
-            ghr -t Egj8XP3dXMaTKj2js7c6QwMwRdIMGd -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete $TAG_NAME out/
+            ghr -t "${KEVIN_GITHUB_TOKEN}" -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete $TAG_NAME out/
             set +x;
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,6 @@ jobs:
     steps:
       - checkout
       - *restore-cache
-      
       - attach_workspace:
           at: website
 
@@ -73,8 +72,39 @@ jobs:
           name: Deploy Website
           command: |
             echo "Deploying website..."
-            cd website 
+            cd website
             GIT_USER=docusaurus-bot USE_SSH= yarn run deploy
+
+  build-and-test:
+    docker:
+      - image: cimg/base:2020.01
+
+    working_directory: ~/profilo
+
+    steps:
+      - checkout
+      - setup_remote_docker
+
+      - run:
+        name: Install dependencies
+        command: |
+          apk add --no-cache \
+            py-pip=9.0.0-r1
+          pip install \
+            docker-compose==1.12.0 \
+            awscli==1.11.76
+      - build:
+        name: Build application Docker image
+        command: |
+          docker build -t profilo -f build/Dockerfile .
+      - test:
+        name: Run tests on Docker
+        command: |
+          docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/test.sh
+          docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/build.sh
+          build/copy_artifacts_to_host.sh
+
+
 
 workflows:
   version: 2
@@ -85,3 +115,6 @@ workflows:
           filters: *filter-only-master
           requires:
             - build-website
+  build_and_test:
+    jobs:
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
 
   build-and-test:
     docker:
-      - image: cimg/base:2020.01
+      - image: circleci/golang:1.8
 
     working_directory: ~/profilo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,12 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            sudo apt-get install docker-ce docker-ce-cli containerd.io golang-go
+            sudo apt-get install docker-ce docker-ce-cli containerd.io
+            wget https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz
+            sudo tar -xvf go1.15.3.linux-amd64.tar.gz
+            sudo mv go /usr/local
+            export GOROOT=/usr/local/go
+            export PATH=$GOROOT/bin:$PATH
       - run:
           name: Build application Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           command: |
             git config --local user.name "Facebook Community Bot"
             git config --local user.email "nobody@nobody.com"
-            VERSION=$(my-binary --version)
+            VERSION=$(echo $CIRCLE_SHA1 | cut -c -7)
             echo "$VERSION"
             echo "$CIRCLE_SHA1"
             echo "$GITHUB_TOKEN"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,9 +89,9 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            sudo apt update
-            sudo apt-get install docker-ce docker-ce-cli containerd.io
-            sudo apt install golang
+            sudo apt update --yes
+            sudo apt-get install docker-ce docker-ce-cli containerd.io --yes
+            sudo apt install golang --yes
       - run:
           name: Build application Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
             sudo apt-get install docker-ce docker-ce-cli containerd.io --yes
             sudo apt install golang --yes
             go get -u github.com/tcnksm/ghr
+            ghr --help
       - run:
           name: Build application Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
             echo "$CIRCLE_PROJECT_USERNAME"
             echo "$CIRCLE_PROJECT_REPONAME"
             set -x;
-            ghr -t "${GITHUB_TOKEN}" -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/.*
+            ghr -t "${GITHUB_TOKEN}" -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} out/
             set +x;
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,11 +90,11 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get install docker-ce docker-ce-cli containerd.io
-      - build:
+      - run:
           name: Build application Docker image
           command: |
             docker build -t profilo -f build/Dockerfile .
-      - test:
+      - run:
           name: Run tests on Docker
           command: |
             docker run -t profilo /usr/bin/env TERM=dumb bash /repo/build/test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-        version: 19.03.13
+          version: 19.03.13
 
       - run:
           name: Install dependencies


### PR DESCRIPTION
Summary: Basically just takes the docker steps from the travis.yml and puts them in circleci's yml

Differential Revision: D26006732

fbshipit-source-id: ef95e6c681ecc13e8f459a65fe5326e3ed8fe007