### PR TITLE
Update runtime.h

### DIFF
--- a/cpp/profiler/unwindc/runtime.h
+++ b/cpp/profiler/unwindc/runtime.h
@@ -136,7 +136,7 @@ uintptr_t get_art_thread() {
 __attribute__((always_inline)) inline uint32_t CountShortyRefs(
     string_t shorty) {
   uint32_t result = 0;
-  for (size_t i = 0; i < shorty.length; i++) {
+  for (size_t i = 1; i < shorty.length; i++) {
     if (shorty.data[i] == 'L') {
       result++;
     }


### PR DESCRIPTION
Hi, @Fortisque @aandreyeu 
It makes the calculator for the ArtMethod FrameSize error which make the unwind progress return by SIGSEGV/SIGBUS. According to https://cs.android.com/android/platform/superproject/+/android-9.0.0_r1:art/runtime/stack.cc;l=699